### PR TITLE
Refine search layout

### DIFF
--- a/src/components/widgets/user/Filter.vue
+++ b/src/components/widgets/user/Filter.vue
@@ -1,40 +1,41 @@
 <template>
-  <div class="bg-white shadow-md rounded-xl p-6 border border-gray-200">
-    <h2 class="text-xl font-semibold mb-4">🔍 Filter</h2>
+  <div class="bg-white shadow-md rounded-xl p-4 border border-gray-200 space-y-4">
+    <h2 class="text-lg font-semibold">🔍 Filter</h2>
 
-    <fieldset class="mb-4">
-      <label class="block mb-1">Umkreis</label>
-      <select v-model="selectedDistance" class="w-full border rounded px-3 py-2">
-        <option v-for="km in [10, 25, 50, 100]" :key="km" :value="km">
-          {{ km }} km
-        </option>
-      </select>
-    </fieldset>
+    <div class="grid sm:grid-cols-2 gap-4">
+      <div>
+        <label class="label">Umkreis</label>
+        <select v-model="selectedDistance" class="input">
+          <option v-for="km in [10, 25, 50, 100]" :key="km" :value="km">
+            {{ km }} km
+          </option>
+        </select>
+      </div>
 
-    <fieldset class="mb-4">
-      <label class="block mb-1">Sortieren</label>
-      <select v-model="sortBy" class="w-full border rounded px-3 py-2">
-        <option value="price_asc">Preis aufsteigend</option>
-        <option value="price_desc">Preis absteigend</option>
-      </select>
-    </fieldset>
+      <div>
+        <label class="label">Sortieren</label>
+        <select v-model="sortBy" class="input">
+          <option value="price_asc">Preis aufsteigend</option>
+          <option value="price_desc">Preis absteigend</option>
+        </select>
+      </div>
+    </div>
 
-    <label class="flex items-center mb-2">
-      <input type="checkbox" v-model="onlyOpen" class="mr-2" />
-      Nur geöffnete Firmen
-    </label>
+    <div class="grid gap-2 sm:grid-cols-2">
+      <label class="flex items-center gap-2">
+        <input type="checkbox" v-model="onlyOpen" class="accent-gold" />
+        <span>Nur geöffnete Firmen</span>
+      </label>
 
-    <label class="flex items-center mb-4">
-      <input type="checkbox" v-model="onlyEmergency" class="mr-2" />
-      Nur mit 24/7 Notdienst
-    </label>
+      <label class="flex items-center gap-2">
+        <input type="checkbox" v-model="onlyEmergency" class="accent-gold" />
+        <span>Nur mit 24/7 Notdienst</span>
+      </label>
+    </div>
 
-    <button
-      @click="apply"
-      class="w-full bg-[#d9a908] hover:bg-yellow-500 text-black font-semibold py-2 rounded"
-    >
-      Filter anwenden
-    </button>
+    <div class="text-right">
+      <button @click="apply" class="btn px-4 py-2">Filter anwenden</button>
+    </div>
   </div>
 </template>
 

--- a/src/components/widgets/user/SearchResultTile.vue
+++ b/src/components/widgets/user/SearchResultTile.vue
@@ -1,26 +1,36 @@
 <template>
   <li
-    class="p-4 bg-white rounded-xl shadow-md border-2 flex items-start gap-4 cursor-pointer hover:shadow-lg"
+    class="p-4 bg-white rounded-xl border flex gap-4 cursor-pointer hover:shadow-md transition"
     :class="borderColor"
     @click="navigateToDetails"
   >
     <img
-      class="w-14 h-14 rounded-full object-cover"
+      class="w-16 h-16 rounded-md object-cover"
       :src="company.logo_url || '/logo.png'"
       alt="Logo"
     />
 
-    <div class="flex-1">
-      <h3 class="font-bold text-lg">{{ company.company_name }}</h3>
-      <p>PLZ: {{ company.postal_code }}</p>
-      <p>Preis: ab {{ company.price }} €</p>
-      <div class="flex items-center gap-2 text-sm">
-        <span class="text-yellow-500">⭐ {{ company.rating?.toFixed(1) || '4.5' }}</span>
+    <div class="flex-1 space-y-1">
+      <div class="flex justify-between items-start">
+        <h3 class="font-semibold text-lg">{{ company.company_name }}</h3>
+        <span class="text-yellow-500 text-sm">
+          <i class="fa fa-star mr-1" />{{ company.rating?.toFixed(1) || '4.5' }}
+        </span>
       </div>
-
-      <p class="font-semibold" :class="statusColor">{{ openStatus }}</p>
-
-      <p v-if="!isOpen && company.is_247 && company.emergency_price" class="text-red-600">
+      <p class="text-sm text-gray-600">PLZ: {{ company.postal_code }}</p>
+      <p class="text-sm">Preis: ab {{ company.price }} €</p>
+      <p>
+        <span
+          class="px-2 py-1 rounded-full text-xs font-semibold"
+          :class="statusClass"
+        >
+          {{ openStatus }}
+        </span>
+      </p>
+      <p
+        v-if="!isOpen && company.is_247 && company.emergency_price"
+        class="text-sm text-red-600"
+      >
         Notdienstpreis: {{ company.emergency_price }} €
       </p>
     </div>
@@ -64,8 +74,12 @@ const openStatus = computed(() => {
   return 'Derzeit geschlossen'
 })
 
-const statusColor = computed(() =>
-  isOpen.value ? 'text-green-600' : props.company.is_247 ? 'text-red-600' : 'text-gray-500'
+const statusClass = computed(() =>
+  isOpen.value
+    ? 'bg-green-100 text-green-800'
+    : props.company.is_247
+      ? 'bg-red-100 text-red-800'
+      : 'bg-gray-100 text-gray-600'
 )
 
 const borderColor = computed(() =>

--- a/src/components/widgets/user/SearchResults.vue
+++ b/src/components/widgets/user/SearchResults.vue
@@ -4,10 +4,12 @@
       Keine Ergebnisse gefunden
     </p>
 
-    <ul v-else class="space-y-4">
-      <li v-for="(company, index) in companies" :key="index">
-        <SearchResultTile :company="company" />
-      </li>
+    <ul v-else class="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+      <SearchResultTile
+        v-for="(company, index) in companies"
+        :key="index"
+        :company="company"
+      />
     </ul>
   </div>
 </template>

--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -1,26 +1,24 @@
 <template>
-  <div class="min-h-screen bg-white px-6 py-8 max-w-4xl mx-auto">
-    <!-- 🔍 PLZ-Suche -->
+  <div class="min-h-screen bg-white px-4 py-8 sm:px-6 max-w-4xl mx-auto">
+    <h1 class="text-2xl font-semibold text-center mb-6">Finde deinen Schlüsseldienst</h1>
+
     <input
       v-model="postalCode"
       type="text"
       inputmode="numeric"
       placeholder="PLZ eingeben"
-      class="w-full mb-4 p-3 border border-gray-300 rounded-lg"
+      class="input mb-4"
     />
 
-    <!-- 🎛️ Filter öffnen -->
     <div class="flex justify-end mb-3">
-      <button @click="toggleFilter" class="text-sm font-semibold text-gold">
-        <i class="fa fa-filter mr-1"></i> Filter
+      <button @click="toggleFilter" class="text-sm font-semibold text-gold flex items-center gap-1">
+        <i class="fa fa-filter" /> <span>Filter</span>
       </button>
     </div>
 
-    <!-- 🔧 Filter-Komponente -->
     <Filter v-if="showFilter" @apply="applyFilters" />
 
-    <!-- 📦 Ergebnisliste -->
-    <div class="mt-4">
+    <div class="mt-6">
       <p v-if="loading">⏳ Firmen werden geladen...</p>
       <template v-else>
         <p v-if="filteredCompanies.length === 0" class="text-gray-500">Keine passenden Firmen gefunden.</p>
@@ -38,7 +36,6 @@ import { collection, getDocs } from 'firebase/firestore'
 
 import Filter from '@/components/widgets/user/Filter.vue'
 import SearchResults from '@/components/widgets/user/SearchResults.vue'
-import SearchResultTile from '@/components/widgets/user/SearchResultTile.vue'
 
 const postalCode = ref('')
 const companies = ref([])


### PR DESCRIPTION
## Summary
- improve HomeView layout and filter toggle
- style filter fields with grid and add checkboxes inline
- revamp search results grid
- polish search result tile design

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685be80597f083219c75bcc1860a66d2