### PR TITLE
Add animations and water-style effects

### DIFF
--- a/src/components/modals/LoginModal.vue
+++ b/src/components/modals/LoginModal.vue
@@ -1,13 +1,20 @@
 <template>
-  <div class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
-    <div class="bg-white rounded-xl p-8 w-full max-w-sm shadow relative">
-      <button @click="$emit('close')" class="absolute top-2 right-2 text-gray-500 hover:text-black">&times;</button>
-      <h2 class="text-xl font-semibold mb-4 text-center text-black">Login für Unternehmen</h2>
-      <Login @success="$emit('close')" />
+  <transition name="fade">
+    <div v-if="show" class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
+      <transition name="modal">
+        <div v-if="show" class="bg-white rounded-xl p-8 w-full max-w-sm shadow relative">
+          <button @click="$emit('close')" class="absolute top-2 right-2 text-gray-500 hover:text-black">&times;</button>
+          <h2 class="text-xl font-semibold mb-4 text-center text-black">Login für Unternehmen</h2>
+          <Login @success="$emit('close')" />
+        </div>
+      </transition>
     </div>
-  </div>
+  </transition>
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import Login from '@/components/Login.vue'
+
+const show = ref(true)
 </script>

--- a/src/components/widgets/user/SearchResultTile.vue
+++ b/src/components/widgets/user/SearchResultTile.vue
@@ -1,6 +1,6 @@
 <template>
   <li
-    class="p-4 bg-white rounded-xl border flex gap-4 cursor-pointer hover:shadow-md transition"
+    class="p-4 bg-white rounded-xl border flex gap-4 cursor-pointer hover:shadow-lg transform transition duration-300 hover:-translate-y-1"
     :class="borderColor"
     @click="navigateToDetails"
   >

--- a/src/theme/index.css
+++ b/src/theme/index.css
@@ -2,14 +2,23 @@
 @tailwind components;
 @tailwind utilities;
 
+@keyframes water-bg {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
 /* 🔤 Fonts & Basics */
 @layer base {
   html {
     font-family: 'Montserrat', sans-serif;
   }
   body {
-      @apply bg-white text-black;
-    }
+    @apply bg-white text-black;
+    background: linear-gradient(135deg, #e0f7fa, #f0f9ff, #e0f7fa);
+    background-size: 400% 400%;
+    animation: water-bg 15s ease infinite;
+  }
 }
 
 /* 🎨 Utilities für Komponenten */
@@ -23,7 +32,7 @@
   }
 
   .btn {
-    @apply bg-gold text-black font-medium py-3 px-6 rounded-full shadow transition-colors duration-200 hover:bg-gold/90 focus:outline-none focus:ring-2 focus:ring-black disabled:opacity-50;
+    @apply bg-gold text-black font-medium py-3 px-6 rounded-full shadow transition duration-200 focus:outline-none focus:ring-2 focus:ring-black disabled:opacity-50 transform hover:scale-105 hover:bg-gold/90;
   }
 
   .btn-danger {
@@ -40,5 +49,26 @@
 
   .form-title {
     @apply text-xl font-semibold mb-2 text-black;
+  }
+
+  /* 🎬 Modal animation */
+  .modal-enter-from,
+  .modal-leave-to {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  .modal-enter-active,
+  .modal-leave-active {
+    transition: all 0.3s ease;
+  }
+
+  /* Fade animation for overlays */
+  .fade-enter-from,
+  .fade-leave-to {
+    opacity: 0;
+  }
+  .fade-enter-active,
+  .fade-leave-active {
+    transition: opacity 0.3s ease;
   }
 }


### PR DESCRIPTION
## Summary
- apply animated gradient background and button hover scaling
- add fade and scale transitions for `LoginModal`
- make search result tiles float on hover

## Testing
- `npm run lint`
- `npm test` *(cancelled watch mode after first run)*

------
https://chatgpt.com/codex/tasks/task_e_685bff9b3a3c8321b674a47d7a97e3a4