### PR TITLE
Add dropdown suggestions for postal code search

### DIFF
--- a/src/components/user/Filter.vue
+++ b/src/components/user/Filter.vue
@@ -1,5 +1,11 @@
 <template>
-  <div class="bg-white shadow-md rounded-xl p-4 border border-gray-200 space-y-4">
+  <div
+    :class="[
+      dropdown
+        ? 'dropdown p-4 space-y-4'
+        : 'bg-white shadow-md rounded-xl p-4 border border-gray-200 space-y-4'
+    ]"
+  >
     <h2 class="text-lg font-semibold">🔍 Filter</h2>
 
     <div class="grid sm:grid-cols-2 gap-4">
@@ -41,6 +47,13 @@
 
 <script setup>
 import { ref } from 'vue'
+
+const { dropdown } = defineProps({
+  dropdown: {
+    type: Boolean,
+    default: false,
+  },
+})
 
 const emit = defineEmits(['apply'])
 

--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -2,21 +2,28 @@
   <div class="min-h-screen bg-white px-4 py-8 sm:px-6 max-w-4xl mx-auto">
     <h1 class="text-2xl font-semibold text-center mb-6">Finde deinen Schlüsseldienst</h1>
 
-    <input
-      v-model="postalCode"
-      type="text"
-      inputmode="numeric"
-      placeholder="PLZ eingeben"
-      class="input mb-4"
-    />
-
-    <div class="flex justify-end mb-3">
-      <button @click="toggleFilter" class="text-sm font-semibold text-gold flex items-center gap-1">
-        <i class="fa fa-filter" /> <span>Filter</span>
-      </button>
+    <div class="relative mb-4">
+      <input
+        v-model="postalCode"
+        type="text"
+        inputmode="numeric"
+        placeholder="PLZ eingeben"
+        class="water-input"
+        @blur="onBlur"
+        @input="onPostalInput"
+      />
+      <ul v-if="showSuggestions" class="dropdown">
+        <li
+          v-for="code in filteredSuggestions"
+          :key="code"
+          class="dropdown-item"
+          @mousedown.prevent="selectSuggestion(code)"
+        >
+          {{ code }}
+        </li>
+      </ul>
+      <Filter v-if="showFilter" dropdown class="mt-1" @apply="applyFilters" />
     </div>
-
-    <Filter v-if="showFilter" @apply="applyFilters" />
 
     <div class="mt-6">
       <p v-if="loading">⏳ Firmen werden geladen...</p>
@@ -40,8 +47,8 @@ import SearchResults from '@/components/user/SearchResults.vue'
 const postalCode = ref('')
 const companies = ref([])
 const loading = ref(true)
-
 const showFilter = ref(false)
+const showSuggestions = ref(false)
 const filters = ref({
   distance: 25,
   sortBy: 'price_asc',
@@ -49,11 +56,39 @@ const filters = ref({
   onlyEmergency: false
 })
 
-const toggleFilter = () => (showFilter.value = !showFilter.value)
-
 const applyFilters = (f) => {
   filters.value = f
   showFilter.value = false
+}
+
+// Liste aller verfügbaren Postleitzahlen
+const allPostalCodes = computed(() => {
+  const codes = companies.value.map((c) => c.postal_code).filter(Boolean)
+  return [...new Set(codes)].sort()
+})
+
+const filteredSuggestions = computed(() =>
+  postalCode.value
+    ? allPostalCodes.value.filter((c) => c.startsWith(postalCode.value)).slice(0, 5)
+    : []
+)
+
+function onPostalInput() {
+  showSuggestions.value = filteredSuggestions.value.length > 0
+  showFilter.value = postalCode.value.length > 0
+}
+
+function onBlur() {
+  window.setTimeout(() => {
+    showSuggestions.value = false
+    if (!postalCode.value) showFilter.value = false
+  }, 100)
+}
+
+function selectSuggestion(code) {
+  postalCode.value = code
+  showSuggestions.value = false
+  showFilter.value = true
 }
 
 // 🔄 Firmen laden

--- a/src/theme/index.css
+++ b/src/theme/index.css
@@ -27,6 +27,20 @@
     @apply w-full px-4 py-3 bg-white border border-gray-300 rounded-md text-sm placeholder-gray-500 focus:outline-none focus:border-black focus:ring-2 focus:ring-black;
   }
 
+  /* 🌊 Wassereffekt für Eingabefelder */
+  .water-input {
+    @apply w-full px-4 py-3 bg-white/70 backdrop-blur-md border border-blue-300 rounded-md text-sm placeholder-gray-500 focus:outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500 transition-colors duration-200;
+  }
+
+  /* Dropdown-Stile für Vorschlagslisten */
+  .dropdown {
+    @apply absolute left-0 right-0 mt-1 bg-white/80 backdrop-blur-md border border-blue-200 rounded-md shadow-lg z-20;
+  }
+
+  .dropdown-item {
+    @apply px-4 py-2 cursor-pointer hover:bg-blue-50;
+  }
+
   .textarea {
     @apply w-full px-4 py-3 bg-white border border-gray-300 rounded-md text-sm resize-none placeholder-gray-500 focus:outline-none focus:border-black focus:ring-2 focus:ring-black;
   }


### PR DESCRIPTION
## Summary
- style inputs and dropdown with new water-inspired classes
- allow `Filter` component to render as dropdown
- enhance Home page with postal code autocomplete and inline filter dropdown

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c1c8903708321abfe5f07a3c6243d