### PR TITLE
Fix login modal closing behavior

### DIFF
--- a/src/components/company/LoginModal.vue
+++ b/src/components/company/LoginModal.vue
@@ -5,7 +5,7 @@
         <div v-if="show" class="bg-white rounded-xl p-8 w-full max-w-sm shadow relative">
           <button @click="$emit('close')" class="absolute top-2 right-2 text-gray-500 hover:text-black">&times;</button>
           <h2 class="text-xl font-semibold mb-4 text-center text-black">Login für Unternehmen</h2>
-          <Login @success="$emit('close')" />
+          <Login @success="$emit('close')" @cancel="$emit('close')" />
         </div>
       </transition>
     </div>


### PR DESCRIPTION
## Summary
- ensure LoginModal listens for the `cancel` event so it closes when navigating to the registration page

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685c22fed0088321aa01bb5216348738