### PR TITLE
Add service unit tests

### DIFF
--- a/src/services/auth.test.js
+++ b/src/services/auth.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/firebase/firebase', () => ({
+  auth: 'auth-instance'
+}))
+
+vi.mock('firebase/auth', () => ({
+  signInWithEmailAndPassword: vi.fn(() => Promise.resolve('signed-in')),
+  sendPasswordResetEmail: vi.fn(() => Promise.resolve()),
+  signOut: vi.fn(() => Promise.resolve())
+}))
+
+import { login, resetPassword, logout } from './auth'
+import { signInWithEmailAndPassword, sendPasswordResetEmail, signOut } from 'firebase/auth'
+
+describe('auth service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('login calls firebase signInWithEmailAndPassword', async () => {
+    await login('test@example.com', 'pass')
+    expect(signInWithEmailAndPassword).toHaveBeenCalledWith('auth-instance', 'test@example.com', 'pass')
+  })
+
+  it('resetPassword calls firebase sendPasswordResetEmail', async () => {
+    await resetPassword('mail@example.com')
+    expect(sendPasswordResetEmail).toHaveBeenCalledWith('auth-instance', 'mail@example.com')
+  })
+
+  it('logout calls firebase signOut', async () => {
+    await logout()
+    expect(signOut).toHaveBeenCalledWith('auth-instance')
+  })
+})

--- a/src/services/storage.test.js
+++ b/src/services/storage.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const firebaseMock = vi.hoisted(() => ({ auth: { currentUser: { uid: 'uid123' } }, storage: 'storage-instance' }))
+const storageRefMock = vi.hoisted(() => vi.fn(() => 'ref'))
+const uploadBytesMock = vi.hoisted(() => vi.fn(() => Promise.resolve()))
+const getDownloadURLMock = vi.hoisted(() => vi.fn(() => Promise.resolve('https://download/url')))
+
+vi.mock('@/firebase/firebase', () => firebaseMock)
+vi.mock('firebase/storage', () => ({
+  ref: storageRefMock,
+  uploadBytes: uploadBytesMock,
+  getDownloadURL: getDownloadURLMock
+}))
+
+import { uploadCompanyLogo } from './storage'
+
+describe('storage service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    firebaseMock.auth.currentUser = { uid: 'uid123' }
+  })
+
+  it('uploads file and returns download url', async () => {
+    const file = new File(['a'], 'logo.png')
+    const url = await uploadCompanyLogo(file)
+    expect(storageRefMock).toHaveBeenCalledWith('storage-instance', 'company_logos/uid123/logo.png')
+    expect(uploadBytesMock).toHaveBeenCalledWith('ref', file)
+    expect(url).toBe('https://download/url')
+  })
+
+  it('throws when not authenticated', async () => {
+    firebaseMock.auth.currentUser = null
+    const file = new File(['b'], 'logo.png')
+    await expect(uploadCompanyLogo(file)).rejects.toThrow('Nicht angemeldet')
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for auth and storage services
- mock firebase modules with vitest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c27288cf0832185ceb3ac2e1ec4b9