### PR TITLE
Add Google login, reviews, and maps

### DIFF
--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -20,4 +20,15 @@ companies (Collection)
     rating: number
 ```
 
-Weitere Sammlungen sind derzeit nicht definiert. Die Authentifizierung erfolgt über Firebase Auth.
+Weitere Sammlungen:
+
+```text
+reviews (Collection)
+  <id> (Document)
+    companyId: string
+    comment: string
+    rating: number
+    created_at: timestamp
+```
+
+Die Authentifizierung erfolgt über Firebase Auth.

--- a/src/components/company/Login.vue
+++ b/src/components/company/Login.vue
@@ -29,6 +29,7 @@
       <span v-if="loading">Lade...</span>
       <span v-else>Einloggen</span>
     </Button>
+    <Button type="button" class="w-full mt-2" @click="googleLogin">Google Login</Button>
 
     <div class="flex flex-col gap-2 mt-4">
       <button
@@ -60,7 +61,7 @@
 <script setup>
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { login as loginService, resetPassword as resetPasswordService } from '@/services/auth'
+import { login as loginService, resetPassword as resetPasswordService, loginWithGoogle } from '@/services/auth'
 import Button from '@/components/common/Button.vue'
 
 defineProps({
@@ -77,6 +78,16 @@ const email = ref('')
 const password = ref('')
 const error = ref('')
 const loading = ref(false)
+
+async function googleLogin() {
+  try {
+    await loginWithGoogle()
+    emit('success')
+    router.push('/dashboard')
+  } catch (e) {
+    error.value = e.message
+  }
+}
 
 const login = async () => {
   error.value = ''

--- a/src/components/user/CommentsSection.vue
+++ b/src/components/user/CommentsSection.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="mt-6">
+    <h2 class="font-semibold mb-2 text-black">Bewertungen</h2>
+    <div v-if="loading" class="text-gray-500">Lade...</div>
+    <ul v-else class="space-y-2">
+      <li v-for="rev in reviews" :key="rev.id" class="p-2 border rounded">
+        <p class="text-sm">{{ rev.comment }}</p>
+        <p class="text-yellow-500 text-sm">{{ '★'.repeat(rev.rating) }}</p>
+      </li>
+    </ul>
+    <form @submit.prevent="submit" class="mt-4 space-y-2">
+      <textarea v-model="comment" class="textarea" placeholder="Kommentar"></textarea>
+      <div class="flex items-center gap-2">
+        <select v-model.number="rating" class="input w-auto">
+          <option v-for="r in [1,2,3,4,5]" :key="r" :value="r">{{ r }}★</option>
+        </select>
+        <Button size="sm" :disabled="saving">Absenden</Button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { db } from '@/firebase/firebase'
+import { collection, query, where, getDocs, addDoc, serverTimestamp } from 'firebase/firestore'
+import Button from '@/components/common/Button.vue'
+
+const props = defineProps({
+  companyId: { type: String, required: true }
+})
+
+const reviews = ref([])
+const loading = ref(true)
+const comment = ref('')
+const rating = ref(5)
+const saving = ref(false)
+
+async function fetchReviews() {
+  const q = query(collection(db, 'reviews'), where('companyId', '==', props.companyId))
+  const snap = await getDocs(q)
+  reviews.value = snap.docs.map(d => ({ id: d.id, ...d.data() }))
+}
+
+onMounted(async () => {
+  await fetchReviews()
+  loading.value = false
+})
+
+async function submit() {
+  if (!comment.value) return
+  saving.value = true
+  try {
+    await addDoc(collection(db, 'reviews'), {
+      companyId: props.companyId,
+      comment: comment.value,
+      rating: rating.value,
+      created_at: serverTimestamp()
+    })
+    comment.value = ''
+    rating.value = 5
+    await fetchReviews()
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/src/components/user/Filter.vue
+++ b/src/components/user/Filter.vue
@@ -25,6 +25,13 @@
           <option value="price_desc">Preis absteigend</option>
         </select>
       </div>
+
+      <div>
+        <label class="label">Mindestbewertung</label>
+        <select v-model.number="minRating" class="input">
+          <option v-for="r in [0,1,2,3,4,5]" :key="r" :value="r">{{ r }}+</option>
+        </select>
+      </div>
     </div>
 
     <div class="grid gap-2 sm:grid-cols-2">
@@ -61,13 +68,15 @@ const selectedDistance = ref(25)
 const sortBy = ref('price_asc')
 const onlyOpen = ref(false)
 const onlyEmergency = ref(false)
+const minRating = ref(0)
 
 const apply = () => {
   emit('apply', {
     distance: selectedDistance.value,
     sortBy: sortBy.value,
     onlyOpen: onlyOpen.value,
-    onlyEmergency: onlyEmergency.value
+    onlyEmergency: onlyEmergency.value,
+    minRating: minRating.value,
   })
 }
 </script>

--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -53,7 +53,8 @@ const filters = ref({
   distance: 25,
   sortBy: 'price_asc',
   onlyOpen: false,
-  onlyEmergency: false
+  onlyEmergency: false,
+  minRating: 0
 })
 
 const applyFilters = (f) => {
@@ -113,6 +114,7 @@ const filteredCompanies = computed(() => {
       const matchesPLZ = company.postal_code?.includes(postalCode.value)
       const onlyOpen = filters.value.onlyOpen
       const onlyEmergency = filters.value.onlyEmergency
+      const minRating = filters.value.minRating
 
       let isOpen = true
       if (onlyOpen) {
@@ -134,8 +136,9 @@ const filteredCompanies = computed(() => {
 
       const matchesOpen = !onlyOpen || isOpen
       const matchesEmergency = !onlyEmergency || company.is_247
+      const matchesRating = (company.rating || 0) >= minRating
 
-      return matchesPLZ && matchesOpen && matchesEmergency
+      return matchesPLZ && matchesOpen && matchesEmergency && matchesRating
     })
     .sort((a, b) => {
       const priceA = parseInt(a.price || '0')

--- a/src/pages/user/CompanyDetailView.vue
+++ b/src/pages/user/CompanyDetailView.vue
@@ -63,14 +63,20 @@ src/pages/user/CompanyDetailView.vue
         >
           <i class="fa fa-phone"></i> Anrufen
         </a>
-        <a
-          :href="`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(fullAddress)}`"
-          target="_blank"
-          class="bg-black text-white font-semibold px-4 py-2 rounded-full flex items-center gap-2"
-        >
-          <i class="fa fa-map-marker"></i> Route
-        </a>
       </div>
+
+      <div class="mt-6">
+        <iframe
+          class="w-full h-64 rounded"
+          :src="mapUrl"
+          style="border:0;"
+          allowfullscreen=""
+          loading="lazy"
+          referrerpolicy="no-referrer-when-downgrade"
+        ></iframe>
+      </div>
+
+      <CommentsSection :companyId="companyId" />
     </div>
   </div>
 </template>
@@ -81,6 +87,7 @@ import { useRoute } from 'vue-router'
 import { db } from '@/firebase/firebase'
 import { doc, getDoc } from 'firebase/firestore'
 import DataRow from '@/components/common/DataRow.vue'
+import CommentsSection from '@/components/user/CommentsSection.vue'
 
 const route = useRoute()
 const companyId = route.params.id
@@ -97,6 +104,7 @@ onMounted(async () => {
 })
 
 const fullAddress = computed(() => `${company.value.postal_code || ''} ${company.value.address || ''}`)
+const mapUrl = computed(() => `https://maps.google.com/maps?q=${encodeURIComponent(fullAddress.value)}&output=embed`)
 
 const now = new Date()
 const currentMinutes = now.getHours() * 60 + now.getMinutes()

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -3,6 +3,8 @@ import {
   signInWithEmailAndPassword,
   sendPasswordResetEmail,
   signOut,
+  GoogleAuthProvider,
+  signInWithPopup,
 } from 'firebase/auth'
 
 export async function login(email, password) {
@@ -15,4 +17,9 @@ export async function resetPassword(email) {
 
 export async function logout() {
   return signOut(auth)
+}
+
+export async function loginWithGoogle() {
+  const provider = new GoogleAuthProvider()
+  return signInWithPopup(auth, provider)
 }

--- a/src/services/auth.test.js
+++ b/src/services/auth.test.js
@@ -7,11 +7,13 @@ vi.mock('@/firebase/firebase', () => ({
 vi.mock('firebase/auth', () => ({
   signInWithEmailAndPassword: vi.fn(() => Promise.resolve('signed-in')),
   sendPasswordResetEmail: vi.fn(() => Promise.resolve()),
-  signOut: vi.fn(() => Promise.resolve())
+  signOut: vi.fn(() => Promise.resolve()),
+  GoogleAuthProvider: vi.fn(),
+  signInWithPopup: vi.fn(() => Promise.resolve('google')),
 }))
 
-import { login, resetPassword, logout } from './auth'
-import { signInWithEmailAndPassword, sendPasswordResetEmail, signOut } from 'firebase/auth'
+import { login, resetPassword, logout, loginWithGoogle } from './auth'
+import { signInWithEmailAndPassword, sendPasswordResetEmail, signOut, signInWithPopup } from 'firebase/auth'
 
 describe('auth service', () => {
   beforeEach(() => {
@@ -31,5 +33,10 @@ describe('auth service', () => {
   it('logout calls firebase signOut', async () => {
     await logout()
     expect(signOut).toHaveBeenCalledWith('auth-instance')
+  })
+
+  it('loginWithGoogle uses signInWithPopup', async () => {
+    await loginWithGoogle()
+    expect(signInWithPopup).toHaveBeenCalled()
   })
 })

--- a/src/services/storage.test.js
+++ b/src/services/storage.test.js
@@ -1,3 +1,4 @@
+/* global File */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const firebaseMock = vi.hoisted(() => ({ auth: { currentUser: { uid: 'uid123' } }, storage: 'storage-instance' }))
@@ -18,6 +19,7 @@ describe('storage service', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     firebaseMock.auth.currentUser = { uid: 'uid123' }
+    globalThis.File = class { constructor(parts, name) { this.parts = parts; this.name = name } }
   })
 
   it('uploads file and returns download url', async () => {


### PR DESCRIPTION
## Summary
- support Google popup login
- allow login modal to trigger Google login
- embed map and comments in company details
- support min rating filter
- document reviews collection in Firestore docs
- add tests for Google login and fix storage tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cdf7d8ff48321b813be76f41ed8f2