### PR TITLE
Add company service helpers and tests

### DIFF
--- a/src/services/company.js
+++ b/src/services/company.js
@@ -1,0 +1,12 @@
+import { db } from '@/firebase/firebase'
+import { collection, getDocs, getDoc, doc } from 'firebase/firestore'
+
+export async function getCompanies() {
+  const snap = await getDocs(collection(db, 'companies'))
+  return snap.docs.map(d => ({ id: d.id, ...d.data() }))
+}
+
+export async function getCompany(id) {
+  const snap = await getDoc(doc(db, 'companies', id))
+  return snap.exists() ? { id: snap.id, ...snap.data() } : null
+}

--- a/src/services/company.test.js
+++ b/src/services/company.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const firestoreMocks = vi.hoisted(() => ({
+  getDocs: vi.fn(),
+  getDoc: vi.fn(),
+  collection: vi.fn(() => 'collection'),
+  doc: vi.fn(() => 'doc')
+}))
+
+vi.mock('@/firebase/firebase', () => ({ db: 'db-instance' }))
+vi.mock('firebase/firestore', () => firestoreMocks)
+
+import { getCompanies, getCompany } from './company'
+
+describe('company service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches all companies', async () => {
+    firestoreMocks.getDocs.mockResolvedValueOnce({
+      docs: [{ id: 'a', data: () => ({ name: 'A' }) }]
+    })
+    const comps = await getCompanies()
+    expect(firestoreMocks.collection).toHaveBeenCalledWith('db-instance', 'companies')
+    expect(comps).toEqual([{ id: 'a', name: 'A' }])
+  })
+
+  it('fetches one company', async () => {
+    firestoreMocks.getDoc.mockResolvedValueOnce({
+      exists: () => true,
+      id: 'a',
+      data: () => ({ name: 'A' })
+    })
+    const comp = await getCompany('a')
+    expect(firestoreMocks.doc).toHaveBeenCalledWith('db-instance', 'companies', 'a')
+    expect(comp).toEqual({ id: 'a', name: 'A' })
+  })
+
+  it('returns null when company not found', async () => {
+    firestoreMocks.getDoc.mockResolvedValueOnce({ exists: () => false })
+    const comp = await getCompany('missing')
+    expect(comp).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- provide `getCompanies` and `getCompany` helpers for Firestore access
- add unit tests for the new company service

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cf564f60883218e18df027a6a50d9