### PR TITLE
Implement modern navigation overlay

### DIFF
--- a/src/components/common/OverlayMenu.vue
+++ b/src/components/common/OverlayMenu.vue
@@ -1,0 +1,50 @@
+<template>
+  <transition name="fade">
+    <div v-if="modelValue" class="fixed inset-0 bg-black/50 backdrop-blur-sm flex justify-end z-50" @click.self="close">
+      <transition name="slide-fade">
+        <nav v-if="modelValue" class="bg-white text-black w-72 max-w-full h-full p-6 rounded-l-3xl shadow-lg overflow-y-auto relative">
+          <button class="absolute top-4 right-4 text-2xl" @click="close">&times;</button>
+          <ul class="mt-8 space-y-4">
+            <li><router-link to="/hilfe" class="hover:text-gold">❓ Hilfe-Center</router-link></li>
+            <li><router-link to="/register" class="hover:text-gold">🛠️ Werde Problemsolver:in</router-link></li>
+            <li><router-link to="/register" class="hover:text-gold">➕ Schlüsseldienst eintragen</router-link></li>
+            <li><router-link to="/" class="hover:text-gold">👥 Partner:in finden</router-link></li>
+            <li><router-link to="/" class="hover:text-gold">🎁 Gutscheine</router-link></li>
+            <li><router-link to="/login" class="hover:text-gold">🔐 Einloggen oder registrieren</router-link></li>
+          </ul>
+        </nav>
+      </transition>
+    </div>
+  </transition>
+</template>
+
+<script setup>
+import { watch } from 'vue'
+
+const props = defineProps({
+  modelValue: Boolean
+})
+const emit = defineEmits(['update:modelValue'])
+
+function close() {
+  emit('update:modelValue', false)
+}
+
+function handleKey(e) {
+  if (e.key === 'Escape') close()
+}
+
+watch(() => props.modelValue, (val) => {
+  if (val) {
+    document.addEventListener('keydown', handleKey)
+  } else {
+    document.removeEventListener('keydown', handleKey)
+  }
+})
+</script>
+
+<style scoped>
+nav a {
+  @apply block font-medium;
+}
+</style>

--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -9,28 +9,38 @@
       <router-link to="/hilfe" class="hover:underline">Hilfe</router-link>
     </nav>
 
-    <div v-if="companyData" class="flex items-center gap-4">
-      <router-link to="/dashboard" class="flex items-center gap-2 hover:underline">
-        <img :src="companyData.logo_url || '/logo.png'" alt="Logo" class="w-9 h-9 rounded-full object-cover" />
-        <span class="font-medium">{{ companyData.company_name }}</span>
-      </router-link>
-      <div class="relative">
-        <button @click="toggleMenu" class="text-xl">⋮</button>
-        <div v-if="showMenu" class="absolute right-0 mt-2 w-48 bg-white text-black rounded shadow z-50">
-          <button @click="goToEdit" class="block px-4 py-2 w-full text-left hover:bg-gray-100">Profil bearbeiten</button>
-          <button @click="logout" class="block px-4 py-2 w-full text-left hover:bg-gray-100">Abmelden</button>
-        </div>
-      </div>
-    </div>
-
-    <div v-else>
-      <button @click="showLogin = true" class="text-xl hover:text-gold" aria-label="Unternehmen">
-        <i class="fa fa-building"></i>
+    <div class="flex items-center gap-3">
+      <button class="text-xl hover:text-gold" aria-label="Sprache">
+        <i class="fa fa-globe"></i>
       </button>
+
+      <button @click="showOverlay = true" class="text-xl hover:text-gold md:hidden" aria-label="Menü">
+        <i class="fa fa-bars"></i>
+      </button>
+
+      <template v-if="companyData">
+        <router-link to="/dashboard" class="flex items-center gap-2 hover:underline">
+          <img :src="companyData.logo_url || '/logo.png'" alt="Logo" class="w-9 h-9 rounded-full object-cover" />
+          <span class="font-medium">{{ companyData.company_name }}</span>
+        </router-link>
+        <div class="relative">
+          <button @click="toggleMenu" class="text-xl">⋮</button>
+          <div v-if="showMenu" class="absolute right-0 mt-2 w-48 bg-white text-black rounded shadow z-50">
+            <button @click="goToEdit" class="block px-4 py-2 w-full text-left hover:bg-gray-100">Profil bearbeiten</button>
+            <button @click="logout" class="block px-4 py-2 w-full text-left hover:bg-gray-100">Abmelden</button>
+          </div>
+        </div>
+      </template>
+
+      <template v-else>
+        <router-link to="/register" class="btn-outline hidden md:inline-block">Werde Problemsolver:in</router-link>
+        <button @click="showLogin = true" class="btn-outline">Einloggen</button>
+      </template>
     </div>
 
     <teleport to="body">
       <LoginModal v-if="showLogin" @close="showLogin = false" />
+      <OverlayMenu v-model="showOverlay" />
     </teleport>
   </header>
 </template>
@@ -42,11 +52,13 @@ import { auth } from '@/firebase/firebase'
 import { doc, getDoc, getFirestore } from 'firebase/firestore'
 import { onAuthStateChanged } from 'firebase/auth'
 import LoginModal from '@/components/company/LoginModal.vue'
+import OverlayMenu from '@/components/common/OverlayMenu.vue'
 
 const db = getFirestore()
 const router = useRouter()
 const showLogin = ref(false)
 const showMenu = ref(false)
+const showOverlay = ref(false)
 const companyData = ref(null)
 
 function toggleMenu() {

--- a/src/theme/index.css
+++ b/src/theme/index.css
@@ -45,6 +45,10 @@
     @apply bg-gold text-black font-medium py-3 px-6 rounded-full shadow transition duration-200 focus:outline-none focus:ring-2 focus:ring-black disabled:opacity-50 transform hover:scale-105 hover:bg-gold/90;
   }
 
+  .btn-outline {
+    @apply bg-white text-gold border border-black font-medium py-3 px-6 rounded-full shadow transition duration-200 hover:bg-gold/10;
+  }
+
   .btn-danger {
     @apply bg-red-600 text-white font-semibold py-3 px-6 rounded-full hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-700;
   }
@@ -78,5 +82,15 @@
   .fade-enter-active,
   .fade-leave-active {
     transition: opacity 0.3s ease-in-out;
+  }
+
+  .slide-fade-enter-from,
+  .slide-fade-leave-to {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+  .slide-fade-enter-active,
+  .slide-fade-leave-active {
+    transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
   }
 }


### PR DESCRIPTION
## Summary
- create overlay navigation with modern menu entries
- add language button placeholder and hamburger menu
- style new outline button and slide-fade transitions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d05a382fc8321a03671955fa94e9b