### PR TITLE
Fix unstable keys in SearchResults

### DIFF
--- a/src/components/user/SearchResults.vue
+++ b/src/components/user/SearchResults.vue
@@ -6,8 +6,8 @@
 
     <ul v-else class="grid grid-cols-1 gap-4 auto-rows-fr">
       <SearchResultTile
-        v-for="(company, index) in companies"
-        :key="index"
+        v-for="company in companies"
+        :key="company.id"
         :company="company"
       />
     </ul>


### PR DESCRIPTION
## Summary
- fix SearchResults component to use company ids as stable keys

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d4e8135388321b23fe794c36fe34a