### PR TITLE
Add opening hours input component

### DIFF
--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -16,6 +16,8 @@ companies (Collection)
     emergency_price: number
     is_247: boolean
     opening_hours: map
+      monday: map { open: string, close: string }
+      ...
     created_at: timestamp
 ```
 

--- a/src/components/company/OpeningHoursForm.vue
+++ b/src/components/company/OpeningHoursForm.vue
@@ -1,0 +1,127 @@
+<template>
+  <div class="form-section">
+    <label class="flex items-center gap-2 mb-2">
+      <input type="checkbox" v-model="sameForAll" />
+      <span class="text-sm">Gilt an allen Tagen die gleichen Öffnungszeiten?</span>
+    </label>
+
+    <div v-if="sameForAll" class="grid grid-cols-2 gap-2 mb-2">
+      <div>
+        <label class="label">Öffnungszeit von</label>
+        <input type="time" v-model="allOpen" class="input" />
+      </div>
+      <div>
+        <label class="label">bis</label>
+        <input type="time" v-model="allClose" class="input" />
+      </div>
+    </div>
+
+    <div v-else class="space-y-2 mb-2">
+      <div
+        v-for="day in days"
+        :key="day.key"
+        class="grid grid-cols-4 items-center gap-2"
+      >
+        <span class="text-sm">{{ day.label }}</span>
+        <input type="time" v-model="openingHours[day.key].open" class="input" />
+        <input type="time" v-model="openingHours[day.key].close" class="input" />
+        <button type="button" class="text-xs text-gray-500" @click="setClosed(day.key)">
+          Geschlossen
+        </button>
+      </div>
+      <button
+        type="button"
+        class="text-sm text-gold underline"
+        @click="copyMonday"
+      >
+        Montag auf alle übernehmen
+      </button>
+    </div>
+
+    <div class="flex gap-4">
+      <button type="button" class="text-sm text-gold underline" @click="set247">
+        24/7
+      </button>
+      <button type="button" class="text-sm text-gold underline" @click="setAllClosed">
+        Alle geschlossen
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+
+const props = defineProps({
+  modelValue: { type: Object, default: () => ({}) }
+})
+const emit = defineEmits(['update:modelValue'])
+
+const days = [
+  { key: 'monday', label: 'Montag' },
+  { key: 'tuesday', label: 'Dienstag' },
+  { key: 'wednesday', label: 'Mittwoch' },
+  { key: 'thursday', label: 'Donnerstag' },
+  { key: 'friday', label: 'Freitag' },
+  { key: 'saturday', label: 'Samstag' },
+  { key: 'sunday', label: 'Sonntag' }
+]
+
+const sameForAll = ref(true)
+const allOpen = ref('')
+const allClose = ref('')
+
+const emptyHours = () => ({ open: '', close: '' })
+const openingHours = ref(
+  days.reduce((acc, d) => ({ ...acc, [d.key]: emptyHours() }), {})
+)
+
+watch(
+  () => props.modelValue,
+  val => {
+    if (!val) return
+    days.forEach(d => {
+      if (val[d.key]) {
+        openingHours.value[d.key] = { ...emptyHours(), ...val[d.key] }
+      }
+    })
+  },
+  { immediate: true }
+)
+
+watch(openingHours, val => emit('update:modelValue', val), { deep: true })
+
+watch([sameForAll, allOpen, allClose], () => {
+  if (sameForAll.value) {
+    days.forEach(d => {
+      openingHours.value[d.key] = { open: allOpen.value, close: allClose.value }
+    })
+  }
+})
+
+function copyMonday() {
+  const m = { ...openingHours.value.monday }
+  days.forEach(d => {
+    openingHours.value[d.key] = { ...m }
+  })
+}
+
+function setClosed(day) {
+  openingHours.value[day] = { open: '', close: '' }
+}
+
+function set247() {
+  allOpen.value = '00:00'
+  allClose.value = '23:59'
+  sameForAll.value = true
+  days.forEach(d => {
+    openingHours.value[d.key] = { open: '00:00', close: '23:59' }
+  })
+}
+
+function setAllClosed() {
+  days.forEach(d => {
+    openingHours.value[d.key] = { open: '', close: '' }
+  })
+}
+</script>

--- a/src/pages/Company/EditView.vue
+++ b/src/pages/Company/EditView.vue
@@ -69,6 +69,8 @@
           :classes="{ label: 'label', input: 'textarea' }"
         />
 
+        <OpeningHoursForm v-model="company.opening_hours" />
+
 
         <FormKit
           type="checkbox"
@@ -105,6 +107,7 @@ import { auth, db } from '@/firebase/firebase'
 import { doc, getDoc, updateDoc, deleteDoc } from 'firebase/firestore'
 import CompanyImageUpload from '@/components/company/CompanyImageUpload.vue'
 import Button from '@/components/common/Button.vue'
+import OpeningHoursForm from '@/components/company/OpeningHoursForm.vue'
 
 const router = useRouter()
 const user = auth.currentUser
@@ -120,6 +123,7 @@ const company = ref({
   logo_url: '',
   is_247: false,
   emergency_price: '',
+  opening_hours: {},
 })
 
 onMounted(async () => {

--- a/src/pages/Company/RegisterView.vue
+++ b/src/pages/Company/RegisterView.vue
@@ -125,6 +125,8 @@
           :classes="{ label: 'label', input: 'textarea' }"
         />
 
+        <OpeningHoursForm v-model="openingHours" />
+
 
         <FormKit
           type="checkbox"
@@ -158,11 +160,13 @@ import { createUserWithEmailAndPassword } from 'firebase/auth'
 import { doc, setDoc, getDoc } from 'firebase/firestore'
 import { loginWithGoogle } from '@/services/auth'
 import Button from '@/components/common/Button.vue'
+import OpeningHoursForm from '@/components/company/OpeningHoursForm.vue'
 
 const router = useRouter()
 const is247 = ref(false)
 const googleLoading = ref(false)
 const googleError = ref('')
+const openingHours = ref({})
 
 
 const register = async (form) => {
@@ -181,6 +185,7 @@ const register = async (form) => {
       postal_code: form.postal_code || '',
       price: form.price || '',
       description: form.description || '',
+      opening_hours: openingHours.value,
       is_247: form.is_247 || false,
       emergency_price: form.is_247 ? form.emergency_price || '' : '',
       created_at: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- capture Firmenöffnungszeiten via new OpeningHoursForm component
- integrate opening hours in registration and profile edit forms
- document opening_hours structure in Firestore docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68655bb5525c8321bf31a817ee88f9cd