### PR TITLE
Fix image upload timing issue

### DIFF
--- a/src/components/company/CompanyImageUpload.vue
+++ b/src/components/company/CompanyImageUpload.vue
@@ -23,9 +23,10 @@ import { uploadCompanyLogo } from '@/services/storage'
 defineProps({
   initialImageUrl: String
 })
-const emit = defineEmits(['uploaded'])
+const emit = defineEmits(['uploaded', 'upload-start', 'upload-end'])
 
 const previewUrl = ref('')
+const isUploading = ref(false)
 
 function uploadImage(e) {
   const file = e.target.files[0]
@@ -41,6 +42,8 @@ function uploadImage(e) {
     return
   }
   previewUrl.value = window.URL.createObjectURL(file)
+  isUploading.value = true
+  emit('upload-start')
   uploadCompanyLogo(file)
     .then(url => {
       previewUrl.value = url
@@ -49,6 +52,10 @@ function uploadImage(e) {
     .catch(err => {
       console.error(err)
       window.alert('Fehler beim Hochladen des Bildes.')
+    })
+    .finally(() => {
+      isUploading.value = false
+      emit('upload-end')
     })
 }
 </script>

--- a/src/pages/Company/EditView.vue
+++ b/src/pages/Company/EditView.vue
@@ -15,6 +15,8 @@
         <CompanyImageUpload
           :initialImageUrl="company.logo_url"
           @uploaded="url => (company.logo_url = url)"
+          @upload-start="logoUploading = true"
+          @upload-end="logoUploading = false"
         />
 
         <FormKit
@@ -92,7 +94,13 @@
         />
 
         <div class="flex gap-4 pt-4">
-          <Button type="submit" class="flex-1">Änderungen speichern</Button>
+          <Button
+            type="submit"
+            class="flex-1"
+            :disabled="logoUploading || saving"
+          >
+            Änderungen speichern
+          </Button>
           <button type="button" @click="confirmDelete" class="btn-danger">Konto löschen</button>
         </div>
       </FormKit>
@@ -111,6 +119,9 @@ import OpeningHoursForm from '@/components/company/OpeningHoursForm.vue'
 
 const router = useRouter()
 const user = auth.currentUser
+
+const logoUploading = ref(false)
+const saving = ref(false)
 
 const company = ref({
   company_name: '',
@@ -135,8 +146,15 @@ onMounted(async () => {
 })
 
 const saveChanges = async () => {
-  if (!user) return
+  if (!user || logoUploading.value) {
+    if (logoUploading.value) {
+      window.alert('Bild wird noch hochgeladen. Bitte warten...')
+    }
+    return
+  }
+  saving.value = true
   await updateDoc(doc(db, 'companies', user.uid), company.value)
+  saving.value = false
   router.push({
     name: 'success',
     query: { msg: 'Änderungen gespeichert', next: '/dashboard' }


### PR DESCRIPTION
## Summary
- emit upload start/end events from `CompanyImageUpload`
- disable save button while upload in progress and wait before saving

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865652f3d008321a616a7386b5d11c1