### PR TITLE
Fix Firebase upload path and tests

### DIFF
--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -2,12 +2,16 @@ import { storage, auth } from '@/firebase/firebase'
 import { ref as storageRef, uploadBytes, getDownloadURL } from 'firebase/storage'
 
 export async function uploadCompanyLogo(file) {
+  console.log('Upload startet, User:', auth.currentUser)
   if (!auth.currentUser) {
     throw new Error('Nicht angemeldet')
   }
-  const path = `company_logos/${auth.currentUser.uid}/${file.name}`
+  const safeName = `${Date.now()}_${file.name.replace(/[^a-zA-Z0-9.]/g, '_')}`
+  const path = `company_logos/${auth.currentUser.uid}/${safeName}`
   const imgRef = storageRef(storage, path)
   await uploadBytes(imgRef, file)
-  return getDownloadURL(imgRef)
+  const url = await getDownloadURL(imgRef)
+  console.log('Upload abgeschlossen, URL:', url)
+  return url
 }
 

--- a/src/services/storage.test.js
+++ b/src/services/storage.test.js
@@ -20,12 +20,13 @@ describe('storage service', () => {
     vi.clearAllMocks()
     firebaseMock.auth.currentUser = { uid: 'uid123' }
     globalThis.File = class { constructor(parts, name) { this.parts = parts; this.name = name } }
+    vi.spyOn(Date, 'now').mockReturnValue(1234567890)
   })
 
   it('uploads file and returns download url', async () => {
-    const file = new File(['a'], 'logo.png')
+    const file = new File(['a'], 'my logo.png')
     const url = await uploadCompanyLogo(file)
-    expect(storageRefMock).toHaveBeenCalledWith('storage-instance', 'company_logos/uid123/logo.png')
+    expect(storageRefMock).toHaveBeenCalledWith('storage-instance', 'company_logos/uid123/1234567890_my_logo.png')
     expect(uploadBytesMock).toHaveBeenCalledWith('ref', file)
     expect(url).toBe('https://download/url')
   })


### PR DESCRIPTION
## Summary
- sanitize file names when uploading company logos
- log upload user and completion
- await download URL retrieval
- adjust unit tests for new behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68656cab54c08321b0d4a9d23830e691