### PR TITLE
Improve filter dropdown style

### DIFF
--- a/src/components/user/Filter.vue
+++ b/src/components/user/Filter.vue
@@ -2,7 +2,7 @@
   <div
     :class="[
       dropdown
-        ? 'dropdown p-4 space-y-4'
+        ? 'dropdown water-filter p-4 space-y-4'
         : 'bg-white shadow-md rounded-xl p-4 border border-gray-200 space-y-4'
     ]"
   >

--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -30,7 +30,9 @@
           {{ code }}
         </li>
       </ul>
-      <Filter v-if="showFilter" dropdown class="mt-1" @apply="applyFilters" />
+      <transition name="water-drop">
+        <Filter v-if="showFilter" dropdown class="mt-1" @apply="applyFilters" />
+      </transition>
     </div>
 
     <div class="mt-6">

--- a/src/theme/index.css
+++ b/src/theme/index.css
@@ -100,4 +100,22 @@
   .slide-fade-leave-active {
     transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
   }
+
+  .water-filter {
+    @apply overflow-hidden rounded-xl backdrop-blur-md border border-gold/50;
+    background: linear-gradient(135deg, #f9f8f8, #fff8d9, #f9f8f8);
+    background-size: 400% 400%;
+    animation: water-bg 10s ease infinite;
+  }
+
+  .water-drop-enter-from,
+  .water-drop-leave-to {
+    opacity: 0;
+    transform: scaleY(0);
+    transform-origin: top;
+  }
+  .water-drop-enter-active,
+  .water-drop-leave-active {
+    transition: opacity 0.3s ease, transform 0.3s ease;
+  }
 }


### PR DESCRIPTION
## Summary
- style the filter dropdown with a water-inspired look
- add smooth transition for filter appearance

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68656fece3148321a207504e3d7ab10e