### PR TITLE
Add email verification

### DIFF
--- a/src/components/company/Login.vue
+++ b/src/components/company/Login.vue
@@ -63,6 +63,8 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { login as loginService, resetPassword as resetPasswordService } from '@/services/auth'
+import { auth, db } from '@/firebase/firebase'
+import { doc, updateDoc } from 'firebase/firestore'
 import Button from '@/components/common/Button.vue'
 import Loader from '@/components/common/Loader.vue'
 
@@ -87,8 +89,13 @@ const login = async () => {
   loading.value = true
   try {
     await loginService(email.value, password.value)
-    emit('success')
-    router.push('/dashboard')
+    if (auth.currentUser?.emailVerified) {
+      await updateDoc(doc(db, 'companies', auth.currentUser.uid), { verified: true })
+      emit('success')
+      router.push('/dashboard')
+    } else {
+      error.value = 'Bitte bestätige zuerst deine E-Mail.'
+    }
   } catch (e) {
     error.value = e.message
   } finally {

--- a/src/pages/Company/RegisterView.vue
+++ b/src/pages/Company/RegisterView.vue
@@ -158,7 +158,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { auth, db } from '@/firebase/firebase'
-import { createUserWithEmailAndPassword } from 'firebase/auth'
+import { createUserWithEmailAndPassword, sendEmailVerification } from 'firebase/auth'
 import { doc, setDoc, getDoc } from 'firebase/firestore'
 import { loginWithGoogle } from '@/services/auth'
 import Button from '@/components/common/Button.vue'
@@ -192,10 +192,14 @@ const register = async (form) => {
       is_247: form.is_247 || false,
       emergency_price: form.is_247 ? form.emergency_price || '' : '',
       created_at: new Date().toISOString(),
+      verified: false,
+    })
+    await sendEmailVerification(user, {
+      url: `${window.location.origin}/verify-email`,
     })
     router.push({
       name: 'success',
-      query: { msg: 'Unternehmen erfolgreich registriert', next: '/dashboard' }
+      query: { msg: 'Bestätige deine E-Mail über den Link', next: '/dashboard' }
     })
   } catch (e) {
     alert('Fehler bei der Registrierung: ' + e.message)
@@ -215,6 +219,7 @@ const registerWithGoogle = async () => {
         email: user.email || '',
         company_name: user.displayName || '',
         created_at: new Date().toISOString(),
+        verified: true,
       }
       await setDoc(docRef, data)
     } else {

--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -53,7 +53,7 @@
 <script setup>
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { db } from '@/firebase/firebase'
-import { collection, getDocs } from 'firebase/firestore'
+import { collection, getDocs, query, where } from 'firebase/firestore'
 
 import Filter from '@/components/user/Filter.vue'
 import SearchResults from '@/components/user/SearchResults.vue'
@@ -146,7 +146,8 @@ onMounted(async () => {
   document.addEventListener('click', handleClickOutside)
   useLocation()
   try {
-    const snapshot = await getDocs(collection(db, 'companies'))
+    const q = query(collection(db, 'companies'), where('verified', '==', true))
+    const snapshot = await getDocs(q)
     companies.value = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
   } catch (err) {
     console.error('Fehler beim Laden:', err)

--- a/src/pages/VerifyEmailView.vue
+++ b/src/pages/VerifyEmailView.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="flex flex-col items-center justify-center text-center min-h-[60vh] px-4">
+    <template v-if="loading">
+      <Loader size="80" />
+      <p class="mt-2">Überprüfe Link...</p>
+    </template>
+    <template v-else-if="success">
+      <lottie-player
+        src="/lotties/haken.json"
+        background="transparent"
+        speed="1"
+        style="width: 200px; height: 200px;"
+        autoplay
+      ></lottie-player>
+      <h1 class="text-2xl font-semibold text-black mt-4">E-Mail bestätigt</h1>
+      <button class="btn mt-6" @click="gotoLogin">Weiter zum Login</button>
+    </template>
+    <p v-else class="text-red-600">Link ist ungültig oder abgelaufen.</p>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { auth, db } from '@/firebase/firebase'
+import { applyActionCode } from 'firebase/auth'
+import { doc, updateDoc } from 'firebase/firestore'
+import Loader from '@/components/common/Loader.vue'
+
+const route = useRoute()
+const router = useRouter()
+const loading = ref(true)
+const success = ref(false)
+
+onMounted(async () => {
+  const code = route.query.oobCode
+  if (!code) {
+    loading.value = false
+    return
+  }
+  try {
+    await applyActionCode(auth, code)
+    if (auth.currentUser) {
+      await updateDoc(doc(db, 'companies', auth.currentUser.uid), { verified: true })
+    }
+    success.value = true
+  } catch (err) {
+    console.error('Verifizierung fehlgeschlagen', err)
+  } finally {
+    loading.value = false
+  }
+})
+
+function gotoLogin() {
+  router.push('/login')
+}
+</script>
+

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -12,6 +12,7 @@ import ImpressumView from '@/pages/ImpressumView.vue'
 import DatenschutzView from '@/pages/DatenschutzView.vue'
 import HelpCenterView from '@/pages/HelpCenterView.vue'
 import SuccessView from '@/pages/SuccessView.vue'
+import VerifyEmailView from '@/pages/VerifyEmailView.vue'
 import ResetPasswordView from '@/pages/ResetPasswordView.vue'
 import NotFoundView from '@/pages/NotFoundView.vue'
 
@@ -48,6 +49,7 @@ const routes = [
       { path: 'datenschutz', name: 'datenschutz', component: DatenschutzView },
       { path: 'hilfe', name: 'help', component: HelpCenterView },
       { path: 'success', name: 'success', component: SuccessView },
+      { path: 'verify-email', name: 'verify-email', component: VerifyEmailView },
     ],
   },
   { path: '/:pathMatch(.*)*', name: 'not-found', component: NotFoundView },

--- a/src/services/company.js
+++ b/src/services/company.js
@@ -1,8 +1,9 @@
 import { db } from '@/firebase/firebase'
-import { collection, getDocs, getDoc, doc } from 'firebase/firestore'
+import { collection, getDocs, getDoc, doc, query, where } from 'firebase/firestore'
 
 export async function getCompanies() {
-  const snap = await getDocs(collection(db, 'companies'))
+  const q = query(collection(db, 'companies'), where('verified', '==', true))
+  const snap = await getDocs(q)
   return snap.docs.map(d => ({ id: d.id, ...d.data() }))
 }
 

--- a/src/services/company.test.js
+++ b/src/services/company.test.js
@@ -4,7 +4,9 @@ const firestoreMocks = vi.hoisted(() => ({
   getDocs: vi.fn(),
   getDoc: vi.fn(),
   collection: vi.fn(() => 'collection'),
-  doc: vi.fn(() => 'doc')
+  doc: vi.fn(() => 'doc'),
+  query: vi.fn((c, w) => ['query', c, w]),
+  where: vi.fn(() => 'where')
 }))
 
 vi.mock('@/firebase/firebase', () => ({ db: 'db-instance' }))
@@ -23,6 +25,8 @@ describe('company service', () => {
     })
     const comps = await getCompanies()
     expect(firestoreMocks.collection).toHaveBeenCalledWith('db-instance', 'companies')
+    expect(firestoreMocks.query).toHaveBeenCalledWith('collection', 'where')
+    expect(firestoreMocks.where).toHaveBeenCalledWith('verified', '==', true)
     expect(comps).toEqual([{ id: 'a', name: 'A' }])
   })
 


### PR DESCRIPTION
## Summary
- require verification at registration and login
- store verification status in Firestore
- show only verified companies on homepage
- add verify-email route and confirmation view
- update unit tests for new query

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686571fc17fc832182af88d6063f8b09