### PR TITLE
Remove email verification requirement

### DIFF
--- a/src/components/company/Login.vue
+++ b/src/components/company/Login.vue
@@ -63,8 +63,6 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { login as loginService, resetPassword as resetPasswordService } from '@/services/auth'
-import { auth, db } from '@/firebase/firebase'
-import { doc, updateDoc } from 'firebase/firestore'
 import Button from '@/components/common/Button.vue'
 import Loader from '@/components/common/Loader.vue'
 
@@ -89,13 +87,8 @@ const login = async () => {
   loading.value = true
   try {
     await loginService(email.value, password.value)
-    if (auth.currentUser?.emailVerified) {
-      await updateDoc(doc(db, 'companies', auth.currentUser.uid), { verified: true })
-      emit('success')
-      router.push('/dashboard')
-    } else {
-      error.value = 'Bitte bestätige zuerst deine E-Mail.'
-    }
+    emit('success')
+    router.push('/dashboard')
   } catch (e) {
     error.value = e.message
   } finally {

--- a/src/components/user/SearchResultTile.vue
+++ b/src/components/user/SearchResultTile.vue
@@ -13,6 +13,7 @@
     <div class="flex-1 space-y-1">
       <div class="flex justify-between items-start">
         <h3 class="font-semibold text-lg">{{ company.company_name }}</h3>
+        <span v-if="!company.verified" class="text-xs text-red-500">Not verified</span>
       </div>
       <p class="text-sm text-gray-600">PLZ: {{ company.postal_code }}</p>
       <p v-if="isOpen" class="text-sm">Preis: ab {{ company.price }} €</p>

--- a/src/pages/Company/RegisterView.vue
+++ b/src/pages/Company/RegisterView.vue
@@ -158,7 +158,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { auth, db } from '@/firebase/firebase'
-import { createUserWithEmailAndPassword, sendEmailVerification } from 'firebase/auth'
+import { createUserWithEmailAndPassword } from 'firebase/auth'
 import { doc, setDoc, getDoc } from 'firebase/firestore'
 import { loginWithGoogle } from '@/services/auth'
 import Button from '@/components/common/Button.vue'
@@ -194,12 +194,9 @@ const register = async (form) => {
       created_at: new Date().toISOString(),
       verified: false,
     })
-    await sendEmailVerification(user, {
-      url: `${window.location.origin}/verify-email`,
-    })
     router.push({
       name: 'success',
-      query: { msg: 'Bestätige deine E-Mail über den Link', next: '/dashboard' }
+      query: { msg: 'Registrierung erfolgreich', next: '/dashboard' }
     })
   } catch (e) {
     alert('Fehler bei der Registrierung: ' + e.message)

--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -53,7 +53,7 @@
 <script setup>
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { db } from '@/firebase/firebase'
-import { collection, getDocs, query, where } from 'firebase/firestore'
+import { collection, getDocs } from 'firebase/firestore'
 
 import Filter from '@/components/user/Filter.vue'
 import SearchResults from '@/components/user/SearchResults.vue'
@@ -146,8 +146,7 @@ onMounted(async () => {
   document.addEventListener('click', handleClickOutside)
   useLocation()
   try {
-    const q = query(collection(db, 'companies'), where('verified', '==', true))
-    const snapshot = await getDocs(q)
+    const snapshot = await getDocs(collection(db, 'companies'))
     companies.value = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
   } catch (err) {
     console.error('Fehler beim Laden:', err)

--- a/src/pages/user/CompanyDetailView.vue
+++ b/src/pages/user/CompanyDetailView.vue
@@ -13,8 +13,9 @@
             alt="Firmenlogo"
             class="w-28 h-28 rounded-full object-cover border border-gray-200 shadow-sm"
           />
-          <h1 class="text-3xl font-bold mt-4 text-black">
+          <h1 class="text-3xl font-bold mt-4 text-black flex items-center gap-2">
             {{ company.company_name || 'Unbekannt' }}
+            <span v-if="!company.verified" class="text-sm text-red-600">Not verified</span>
           </h1>
           <p class="text-sm text-gray-500 mt-1">{{ fullAddress }}</p>
         </div>

--- a/src/services/company.js
+++ b/src/services/company.js
@@ -1,9 +1,8 @@
 import { db } from '@/firebase/firebase'
-import { collection, getDocs, getDoc, doc, query, where } from 'firebase/firestore'
+import { collection, getDocs, getDoc, doc } from 'firebase/firestore'
 
 export async function getCompanies() {
-  const q = query(collection(db, 'companies'), where('verified', '==', true))
-  const snap = await getDocs(q)
+  const snap = await getDocs(collection(db, 'companies'))
   return snap.docs.map(d => ({ id: d.id, ...d.data() }))
 }
 

--- a/src/services/company.test.js
+++ b/src/services/company.test.js
@@ -4,9 +4,7 @@ const firestoreMocks = vi.hoisted(() => ({
   getDocs: vi.fn(),
   getDoc: vi.fn(),
   collection: vi.fn(() => 'collection'),
-  doc: vi.fn(() => 'doc'),
-  query: vi.fn((c, w) => ['query', c, w]),
-  where: vi.fn(() => 'where')
+  doc: vi.fn(() => 'doc')
 }))
 
 vi.mock('@/firebase/firebase', () => ({ db: 'db-instance' }))
@@ -25,8 +23,7 @@ describe('company service', () => {
     })
     const comps = await getCompanies()
     expect(firestoreMocks.collection).toHaveBeenCalledWith('db-instance', 'companies')
-    expect(firestoreMocks.query).toHaveBeenCalledWith('collection', 'where')
-    expect(firestoreMocks.where).toHaveBeenCalledWith('verified', '==', true)
+    expect(firestoreMocks.getDocs).toHaveBeenCalledWith('collection')
     expect(comps).toEqual([{ id: 'a', name: 'A' }])
   })
 


### PR DESCRIPTION
## Summary
- fetch all companies in service and on home page
- remove email verification check from login
- stop sending verification email on registration
- show "Not verified" badge if a company is unverified
- update tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686635bd9f1c8321abf6cbfbfa7f5784