### PR TITLE
Handle new Firestore rules

### DIFF
--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -52,8 +52,7 @@
 
 <script setup>
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
-import { db } from '@/firebase/firebase'
-import { collection, getDocs } from 'firebase/firestore'
+import { getCompanies } from '@/services/company'
 
 import Filter from '@/components/user/Filter.vue'
 import SearchResults from '@/components/user/SearchResults.vue'
@@ -146,8 +145,7 @@ onMounted(async () => {
   document.addEventListener('click', handleClickOutside)
   useLocation()
   try {
-    const snapshot = await getDocs(collection(db, 'companies'))
-    companies.value = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
+    companies.value = await getCompanies()
   } catch (err) {
     console.error('Fehler beim Laden:', err)
   } finally {

--- a/src/pages/user/CompanyDetailView.vue
+++ b/src/pages/user/CompanyDetailView.vue
@@ -74,8 +74,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
-import { db } from '@/firebase/firebase'
-import { doc, getDoc } from 'firebase/firestore'
+import { getCompany } from '@/services/company'
 import DataRow from '@/components/common/DataRow.vue'
 
 const route = useRoute()
@@ -85,9 +84,13 @@ const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'
 
 onMounted(async () => {
   if (companyId) {
-    const snapshot = await getDoc(doc(db, 'companies', companyId))
-    if (snapshot.exists()) {
-      company.value = snapshot.data()
+    try {
+      const data = await getCompany(companyId)
+      if (data) {
+        company.value = data
+      }
+    } catch (err) {
+      console.error('Fehler beim Laden:', err)
     }
   }
 })

--- a/src/services/company.js
+++ b/src/services/company.js
@@ -1,8 +1,9 @@
 import { db } from '@/firebase/firebase'
-import { collection, getDocs, getDoc, doc } from 'firebase/firestore'
+import { collection, getDocs, getDoc, doc, query, where } from 'firebase/firestore'
 
 export async function getCompanies() {
-  const snap = await getDocs(collection(db, 'companies'))
+  const q = query(collection(db, 'companies'), where('verified', '==', true))
+  const snap = await getDocs(q)
   return snap.docs.map(d => ({ id: d.id, ...d.data() }))
 }
 

--- a/src/services/company.test.js
+++ b/src/services/company.test.js
@@ -4,7 +4,9 @@ const firestoreMocks = vi.hoisted(() => ({
   getDocs: vi.fn(),
   getDoc: vi.fn(),
   collection: vi.fn(() => 'collection'),
-  doc: vi.fn(() => 'doc')
+  doc: vi.fn(() => 'doc'),
+  query: vi.fn(() => 'query'),
+  where: vi.fn(() => 'where')
 }))
 
 vi.mock('@/firebase/firebase', () => ({ db: 'db-instance' }))
@@ -23,7 +25,9 @@ describe('company service', () => {
     })
     const comps = await getCompanies()
     expect(firestoreMocks.collection).toHaveBeenCalledWith('db-instance', 'companies')
-    expect(firestoreMocks.getDocs).toHaveBeenCalledWith('collection')
+    expect(firestoreMocks.where).toHaveBeenCalledWith('verified', '==', true)
+    expect(firestoreMocks.query).toHaveBeenCalledWith('collection', 'where')
+    expect(firestoreMocks.getDocs).toHaveBeenCalledWith('query')
     expect(comps).toEqual([{ id: 'a', name: 'A' }])
   })
 


### PR DESCRIPTION
## Summary
- filter company fetches to only include verified entries
- use the new company service functions in views
- adjust tests for new Firestore query logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686639acd9d48321b963b8b2186a83ad