### PR TITLE
Fix postal code function CORS

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2,17 +2,30 @@
 /* global fetch */
 const functions = require('firebase-functions')
 const admin = require('firebase-admin')
+const cors = require('cors')({ origin: true })
 
 admin.initializeApp()
 
-exports.postalCodeFromCoords = functions.https.onCall(async (data) => {
-  const { lat, lng } = data
-  const key = functions.config().maps && functions.config().maps.key
-  if (!key) {
-    throw new functions.https.HttpsError('failed-precondition', 'API key missing')
-  }
-  const res = await fetch(`https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&key=${key}`)
-  const json = await res.json()
-  const component = json.results[0]?.address_components.find((c) => c.types.includes('postal_code'))
-  return { postalCode: component?.long_name || '' }
+exports.postalCodeFromCoords = functions.https.onRequest((req, res) => {
+  cors(req, res, async () => {
+    if (req.method !== 'POST') {
+      res.status(400).send('Only POST requests allowed')
+      return
+    }
+    const { lat, lng } = req.body || {}
+    const key = functions.config().maps && functions.config().maps.key
+    if (!key) {
+      res.status(500).json({ error: 'API key missing' })
+      return
+    }
+    try {
+      const resp = await fetch(`https://maps.googleapis.com/maps/api/geocode/json?latlng=${lat},${lng}&key=${key}`)
+      const json = await resp.json()
+      const component = json.results[0]?.address_components.find((c) => c.types.includes('postal_code'))
+      res.json({ postalCode: component?.long_name || '' })
+    } catch (err) {
+      console.error(err)
+      res.status(500).json({ error: 'internal' })
+    }
+  })
 })

--- a/functions/package.json
+++ b/functions/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "firebase-admin": "^11.10.1",
-    "firebase-functions": "^4.4.0"
+    "firebase-functions": "^4.4.0",
+    "cors": "^2.8.5"
   }
 }

--- a/src/firebase/functions.js
+++ b/src/firebase/functions.js
@@ -1,9 +1,18 @@
-import { getFunctions, httpsCallable } from 'firebase/functions'
-import { app } from '../firebase'
+/* global fetch */
+export async function getPostalFromCoords(lat, lng) {
+  const url =
+    import.meta.env.VITE_FUNCTION_URL ||
+    `https://us-central1-${import.meta.env.VITE_FIREBASE_PROJECT_ID}.cloudfunctions.net/postalCodeFromCoords`
 
-const functions = getFunctions(app)
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ lat, lng }),
+  })
 
-export function getPostalFromCoords(lat, lng) {
-  const fn = httpsCallable(functions, 'postalCodeFromCoords')
-  return fn({ lat, lng }).then(r => r.data)
+  if (!res.ok) {
+    throw new Error('Request failed')
+  }
+
+  return res.json()
 }


### PR DESCRIPTION
## Summary
- add cors dependency for Cloud Functions
- expose `postalCodeFromCoords` via `https.onRequest` and handle CORS
- call the function with `fetch` from frontend

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686679969ce08321918cfb5dc74f8996