### PR TITLE
Add profile verification email

### DIFF
--- a/src/pages/Company/EditView.vue
+++ b/src/pages/Company/EditView.vue
@@ -5,6 +5,20 @@
     </h1>
 
     <Transition name="fade">
+      <div v-if="!company.verified" class="bg-yellow-50 border-l-4 border-yellow-400 p-4 rounded mb-4">
+        <p class="text-yellow-800">Dein Profil ist noch nicht verifiziert.</p>
+        <Button
+          size="sm"
+          class="mt-2"
+          type="button"
+          @click="verifyProfile"
+          :disabled="verificationSending"
+        >
+          <template v-if="verificationSending">Senden...</template>
+          <template v-else>Verifizierungsmail senden</template>
+        </Button>
+        <p v-if="verificationSent" class="text-green-600 text-sm mt-2">E-Mail wurde gesendet.</p>
+      </div>
       <FormKit
         type="form"
         :actions="false"
@@ -116,12 +130,15 @@ import { doc, getDoc, updateDoc, deleteDoc } from 'firebase/firestore'
 import CompanyImageUpload from '@/components/company/CompanyImageUpload.vue'
 import Button from '@/components/common/Button.vue'
 import OpeningHoursForm from '@/components/company/OpeningHoursForm.vue'
+import { sendVerificationEmail } from '@/services/auth'
 
 const router = useRouter()
 const user = auth.currentUser
 
 const logoUploading = ref(false)
 const saving = ref(false)
+const verificationSending = ref(false)
+const verificationSent = ref(false)
 
 const company = ref({
   company_name: '',
@@ -168,5 +185,18 @@ const confirmDelete = async () => {
   await user.delete()
   window.alert('Konto gelöscht')
   router.push('/')
+}
+
+const verifyProfile = async () => {
+  if (!user) return
+  verificationSending.value = true
+  try {
+    await sendVerificationEmail(user)
+    verificationSent.value = true
+  } catch (e) {
+    window.alert('Fehler beim Senden der Verifizierungsmail: ' + e.message)
+  } finally {
+    verificationSending.value = false
+  }
 }
 </script>

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -6,6 +6,7 @@ import {
   signOut,
   GoogleAuthProvider,
   signInWithPopup,
+  sendEmailVerification,
 } from 'firebase/auth'
 
 export async function login(email, password) {
@@ -27,4 +28,13 @@ export async function loginWithGoogle() {
 
 export async function register(email, password) {
   return createUserWithEmailAndPassword(auth, email, password)
+}
+
+export async function sendVerificationEmail(user = auth.currentUser) {
+  if (!user) throw new Error('No user')
+  const actionCodeSettings = {
+    url: (typeof window !== 'undefined' ? window.location.origin : '') + '/verify-email',
+    handleCodeInApp: true,
+  }
+  return sendEmailVerification(user, actionCodeSettings)
 }

--- a/src/services/auth.test.js
+++ b/src/services/auth.test.js
@@ -11,10 +11,11 @@ vi.mock('firebase/auth', () => ({
   signOut: vi.fn(() => Promise.resolve()),
   GoogleAuthProvider: vi.fn(),
   signInWithPopup: vi.fn(() => Promise.resolve('google')),
+  sendEmailVerification: vi.fn(() => Promise.resolve()),
 }))
 
-import { login, resetPassword, logout, loginWithGoogle, register } from './auth'
-import { signInWithEmailAndPassword, createUserWithEmailAndPassword, sendPasswordResetEmail, signOut, signInWithPopup } from 'firebase/auth'
+import { login, resetPassword, logout, loginWithGoogle, register, sendVerificationEmail } from './auth'
+import { signInWithEmailAndPassword, createUserWithEmailAndPassword, sendPasswordResetEmail, signOut, signInWithPopup, sendEmailVerification } from 'firebase/auth'
 
 describe('auth service', () => {
   beforeEach(() => {
@@ -45,4 +46,11 @@ describe('auth service', () => {
     await register('new@mail.com', 'secret')
     expect(createUserWithEmailAndPassword).toHaveBeenCalledWith('auth-instance', 'new@mail.com', 'secret')
   })
+
+  it('sendVerificationEmail calls firebase sendEmailVerification', async () => {
+    const user = { uid: '1' }
+    await sendVerificationEmail(user)
+    expect(sendEmailVerification).toHaveBeenCalled()
+  })
 })
+


### PR DESCRIPTION
## Summary
- allow sending verification email via auth service
- test sendVerificationEmail
- let company profile trigger sending verification mail if not verified

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68668827805083219e7f458fa83d4278