### PR TITLE
Add global background image

### DIFF
--- a/public/background.svg
+++ b/public/background.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="1024" viewBox="0 0 1440 1024">
+  <defs>
+    <linearGradient id="bg-grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fffdf4" />
+      <stop offset="100%" stop-color="#f7efd0" />
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="1024" fill="url(#bg-grad)" />
+  <path d="M0 300 Q360 200 720 300T1440 300V1024H0Z" fill="#ffffff" opacity="0.5" />
+</svg>

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col min-h-screen bg-white text-black">
+  <div class="flex flex-col min-h-screen text-black">
     <Header />
     <main class="flex-1 flex justify-center items-start pt-20">
       <div class="w-full max-w-4xl px-6 py-8">

--- a/src/theme/index.css
+++ b/src/theme/index.css
@@ -21,8 +21,9 @@
   }
   body {
     @apply bg-white text-black;
-    background: linear-gradient(135deg, #f9f8f8, #fff8d9, #f9f8f8);
-    background-size: 400% 400%;
+    background-image: url('/background.svg'), linear-gradient(135deg, #f9f8f8, #fff8d9, #f9f8f8);
+    background-size: cover, 400% 400%;
+    background-repeat: no-repeat;
     animation: water-bg 15s ease infinite;
   }
 }


### PR DESCRIPTION
## Summary
- include background.svg asset
- use the new background in global CSS
- let the layout be transparent so the body background is visible

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68669b5e10948321b40002c3acb3b283