### PR TITLE
Add simple language switch

### DIFF
--- a/src/components/common/OverlayMenu.vue
+++ b/src/components/common/OverlayMenu.vue
@@ -6,22 +6,22 @@
     >
       <ul class="space-y-3">
         <li>
-          <router-link to="/hilfe" class="menu-link">Hilfe-Center</router-link>
+          <router-link to="/hilfe" class="menu-link">{{ t('overlay.helpCenter') }}</router-link>
         </li>
         <li v-if="!companyData">
-          <router-link to="/register" class="menu-link">Problemsolver:in werden</router-link>
+          <router-link to="/register" class="menu-link">{{ t('overlay.becomeSolver') }}</router-link>
         </li>
         <li>
-          <router-link to="/" class="menu-link">Schlosser finden</router-link>
+          <router-link to="/" class="menu-link">{{ t('overlay.findLocksmith') }}</router-link>
         </li>
         <li v-if="!companyData">
-          <router-link to="/login" class="menu-link">Einloggen</router-link>
+          <router-link to="/login" class="menu-link">{{ t('overlay.login') }}</router-link>
         </li>
         <li v-if="companyData">
-          <router-link to="/edit" class="menu-link">Profil bearbeiten</router-link>
+          <router-link to="/edit" class="menu-link">{{ t('overlay.editProfile') }}</router-link>
         </li>
         <li v-if="companyData">
-          <button @click="$emit('logout')" class="menu-link w-full text-left">Abmelden</button>
+          <button @click="$emit('logout')" class="menu-link w-full text-left">{{ t('overlay.logout') }}</button>
         </li>
       </ul>
     </div>
@@ -29,13 +29,15 @@
 </template>
 
 <script setup>
-import { watch } from 'vue'
+import { watch, inject } from 'vue'
 
 const props = defineProps({
   modelValue: Boolean,
   companyData: Object
 })
 const emit = defineEmits(['update:modelValue', 'logout'])
+
+const t = inject('t')
 
 function close() {
   emit('update:modelValue', false)

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,0 +1,91 @@
+import { ref } from 'vue'
+
+const messages = {
+  de: {
+    header: {
+      becomeSolver: 'Werde Problemsolver:in',
+      language: 'Sprache'
+    },
+    overlay: {
+      helpCenter: 'Hilfe-Center',
+      becomeSolver: 'Problemsolver:in werden',
+      findLocksmith: 'Schlosser finden',
+      login: 'Einloggen',
+      editProfile: 'Profil bearbeiten',
+      logout: 'Abmelden'
+    },
+    footer: {
+      impressum: 'Impressum',
+      datenschutz: 'Datenschutz',
+      blog: 'Blog'
+    },
+    home: {
+      heading: 'Magikey, der Schlüsseldienst in deiner Nähe',
+      searchPlaceholder: 'Wo brauchst du Hilfe? Postleitzahl',
+      loading: 'Firmen werden geladen...',
+      noResults: 'Leider kein Anbieter gefunden. Trag dich ein, wir benachrichtigen dich!'
+    },
+    impressum: {
+      title: 'Impressum'
+    },
+    datenschutz: {
+      title: 'Datenschutzerklärung'
+    }
+  },
+  en: {
+    header: {
+      becomeSolver: 'Become a problemsolver',
+      language: 'Language'
+    },
+    overlay: {
+      helpCenter: 'Help Center',
+      becomeSolver: 'Become a problemsolver',
+      findLocksmith: 'Find locksmith',
+      login: 'Login',
+      editProfile: 'Edit profile',
+      logout: 'Logout'
+    },
+    footer: {
+      impressum: 'Impressum',
+      datenschutz: 'Privacy',
+      blog: 'Blog'
+    },
+    home: {
+      heading: 'Magikey, locksmith near you',
+      searchPlaceholder: 'Where do you need help? Enter postal code',
+      loading: 'Loading companies...',
+      noResults: 'No providers found. Sign up and we will notify you!'
+    },
+    impressum: {
+      title: 'Legal notice'
+    },
+    datenschutz: {
+      title: 'Privacy policy'
+    }
+  }
+}
+
+const storage = typeof window !== 'undefined' && window.localStorage ? window.localStorage : {
+  getItem: () => null,
+  setItem: () => {}
+}
+const locale = ref(storage.getItem('locale') || 'de')
+
+function t(key) {
+  return key.split('.').reduce((obj, k) => obj && obj[k], messages[locale.value]) || key
+}
+
+function setLocale(l) {
+  locale.value = l
+  storage.setItem('locale', l)
+}
+
+export default {
+  install(app) {
+    app.config.globalProperties.$t = t
+    app.config.globalProperties.$setLocale = setLocale
+    app.provide('t', t)
+    app.provide('locale', locale)
+    app.provide('setLocale', setLocale)
+  }
+}

--- a/src/layouts/Footer.vue
+++ b/src/layouts/Footer.vue
@@ -1,13 +1,18 @@
 <template>
   <footer class="bg-black text-white py-4 px-6 text-sm text-center mt-auto">
     <div class="flex justify-center items-center gap-4 text-white/70">
-      <router-link to="/impressum" class="hover:underline">Impressum</router-link>
+      <router-link to="/impressum" class="hover:underline">{{ t('footer.impressum') }}</router-link>
       <span class="opacity-40">|</span>
-      <router-link to="/datenschutz" class="hover:underline">Datenschutz</router-link>
+      <router-link to="/datenschutz" class="hover:underline">{{ t('footer.datenschutz') }}</router-link>
       <span class="opacity-40">|</span>
-      <a href="/blog" target="_blank" class="hover:underline">Blog</a>
+      <a href="/blog" target="_blank" class="hover:underline">{{ t('footer.blog') }}</a>
     </div>
   </footer>
 </template>
+
+<script setup>
+import { inject } from 'vue'
+const t = inject('t')
+</script>
 
 

--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -19,12 +19,13 @@
       <template v-if="!companyData">
         <router-link to="/register" class="btn-outline hidden md:inline-flex items-center">
           <i class="fa fa-key mr-2 animate-bounce"></i>
-          Werde Problemsolver:in
+          {{ t('header.becomeSolver') }}
         </router-link>
       </template>
 
-      <button class="text-xl hover:text-gold focus:outline-none" aria-label="Sprache">
+      <button @click="toggleLanguage" class="text-xl hover:text-gold focus:outline-none flex items-center" aria-label="Sprache">
         <i class="fa fa-globe"></i>
+        <span class="ml-1 text-sm uppercase">{{ locale }}</span>
       </button>
 
       <button
@@ -45,7 +46,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { ref, onMounted, onBeforeUnmount, inject } from 'vue'
 import { useRouter } from 'vue-router'
 import { auth } from '@/firebase'
 import { doc, getDoc, getFirestore } from 'firebase/firestore'
@@ -57,9 +58,16 @@ const router = useRouter()
 const showOverlay = ref(false)
 const companyData = ref(null)
 const menuButton = ref(null)
+const t = inject('t')
+const locale = inject('locale')
+const setLocale = inject('setLocale')
 
 function toggleOverlay() {
   showOverlay.value = !showOverlay.value
+}
+
+function toggleLanguage() {
+  setLocale(locale.value === 'de' ? 'en' : 'de')
 }
 
 function handleClickOutside(event) {

--- a/src/main.js
+++ b/src/main.js
@@ -3,11 +3,14 @@ import App from './App.vue'
 import router from './router/index.js'
 import './theme/index.css'
 
+import i18n from './i18n/index.js'
+
 import { plugin, defaultConfig } from '@formkit/vue'
 import '@formkit/themes/genesis'
 
 const app = createApp(App)
 
 app.use(router)
+app.use(i18n)
 app.use(plugin, defaultConfig)
 app.mount('#app')

--- a/src/pages/DatenschutzView.vue
+++ b/src/pages/DatenschutzView.vue
@@ -1,7 +1,12 @@
 <template>
   <div class="max-w-2xl mx-auto p-6">
-    <h1 class="text-2xl font-bold mb-4">Datenschutzerklärung</h1>
+    <h1 class="text-2xl font-bold mb-4">{{ t('datenschutz.title') }}</h1>
     <p>Hier folgt deine Datenschutzerklärung. Diese Inhalte sind Platzhalter.</p>
   </div>
 </template>
+
+<script setup>
+import { inject } from 'vue'
+const t = inject('t')
+</script>
 

--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen bg-white px-4 py-8 sm:px-6 max-w-4xl mx-auto">
-    <h1 class="text-2xl font-semibold text-center mb-6">Magikey, der Schlüsseldienst in deiner Nähe</h1>
+    <h1 class="text-2xl font-semibold text-center mb-6">{{ t('home.heading') }}</h1>
 
 <div class="relative mb-4" ref="searchContainer">
       <input
@@ -8,7 +8,7 @@
         type="text"
         inputmode="numeric"
         maxlength="5"
-        placeholder="Wo brauchst du Hilfe gebe hier eine Postleitzahl ein !"
+        :placeholder="t('home.searchPlaceholder')"
         class="water-input pr-12 rounded-full"
         @focus="onFocus"
         @blur="onBlur"
@@ -36,11 +36,11 @@
     <div class="mt-6">
       <div v-if="loading" class="flex flex-col items-center py-10 text-gray-500">
         <Loader :size="80" />
-        <p class="mt-2">Firmen werden geladen...</p>
+        <p class="mt-2">{{ t('home.loading') }}</p>
       </div>
       <template v-else>
         <div v-if="filteredCompanies.length === 0" class="text-gray-500">
-          <p>Leider kein Anbieter gefunden. Trag dich ein, wir benachrichtigen dich!</p>
+          <p>{{ t('home.noResults') }}</p>
           <NotifyForm />
         </div>
         <SearchResults v-else :companies="filteredCompanies" />
@@ -51,7 +51,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, inject } from 'vue'
 import { getCompanies } from '@/services/company'
 
 import Filter from '@/components/user/Filter.vue'
@@ -59,6 +59,8 @@ import SearchResults from '@/components/user/SearchResults.vue'
 import NotifyForm from '@/components/user/NotifyForm.vue'
 import Loader from '@/components/common/Loader.vue'
 import { getPostalFromCoords } from '@/firebase/functions'
+
+const t = inject('t')
 
 const postalCode = ref('')
 const companies = ref([])

--- a/src/pages/ImpressumView.vue
+++ b/src/pages/ImpressumView.vue
@@ -1,7 +1,12 @@
 <template>
   <div class="max-w-2xl mx-auto p-6">
-    <h1 class="text-2xl font-bold mb-4">Impressum</h1>
+    <h1 class="text-2xl font-bold mb-4">{{ t('impressum.title') }}</h1>
     <p>Diese Seite dient nur als Demo. Trage hier deine Impressumsangaben ein.</p>
   </div>
 </template>
+
+<script setup>
+import { inject } from 'vue'
+const t = inject('t')
+</script>
 


### PR DESCRIPTION
## Summary
- create custom i18n plugin with English and German messages
- mount i18n plugin in the app
- allow language toggle in header
- translate overlay menu, footer, home page and info pages

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68669b9226908321a62d91eb7e96e768