### PR TITLE
Fix missing lucide icons by adding local components

### DIFF
--- a/src/components/icons/ChevronDown.vue
+++ b/src/components/icons/ChevronDown.vue
@@ -1,0 +1,7 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+</template>
+<script setup>
+</script>

--- a/src/components/icons/Clock.vue
+++ b/src/components/icons/Clock.vue
@@ -1,0 +1,8 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="12" r="10" />
+    <polyline points="12 6 12 12 16 14" />
+  </svg>
+</template>
+<script setup>
+</script>

--- a/src/components/icons/Euro.vue
+++ b/src/components/icons/Euro.vue
@@ -1,0 +1,8 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M17 5h-6a4 4 0 0 0 0 8h6" />
+    <path d="M17 19h-6a4 4 0 0 1 0-8h6" />
+  </svg>
+</template>
+<script setup>
+</script>

--- a/src/components/icons/MapPin.vue
+++ b/src/components/icons/MapPin.vue
@@ -1,0 +1,8 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 1 1 18 0z" />
+    <circle cx="12" cy="10" r="3" />
+  </svg>
+</template>
+<script setup>
+</script>

--- a/src/components/icons/X.vue
+++ b/src/components/icons/X.vue
@@ -1,0 +1,8 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="18" y1="6" x2="6" y2="18" />
+    <line x1="6" y1="6" x2="18" y2="18" />
+  </svg>
+</template>
+<script setup>
+</script>

--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -1,0 +1,5 @@
+export { default as Clock } from './Clock.vue'
+export { default as Euro } from './Euro.vue'
+export { default as MapPin } from './MapPin.vue'
+export { default as ChevronDown } from './ChevronDown.vue'
+export { default as X } from './X.vue'

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      'lucide-vue-next': path.resolve(__dirname, './src/components/icons'),
     },
   },
 })


### PR DESCRIPTION
## Summary
- provide local SVG icon components to replace `lucide-vue-next`
- alias `lucide-vue-next` to use these local icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866a4f0d82c8321a1dc60ce03b67358