### PR TITLE
Fix filter bar state handling

### DIFF
--- a/src/components/user/FilterBar.vue
+++ b/src/components/user/FilterBar.vue
@@ -65,25 +65,21 @@
 </template>
 
 <script setup>
-import { reactive, ref, watch, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, watch, computed, onMounted, onBeforeUnmount } from 'vue'
 import { MapPin, Clock, Euro, ChevronDown, Search, X } from '@/components/icons'
 import FilterPriceSheet from './FilterPriceSheet.vue'
+import { filters } from '@/stores/filters'
 
-const props = defineProps({
-  modelValue: {
-    type: Object,
-    default: () => ({ openNow: false, price: [0, 1000], location: '' })
-  },
+defineProps({
   expanded: {
     type: Boolean,
-    default: false
-  }
+    default: false,
+  },
 })
 
-const emit = defineEmits(['update:modelValue', 'focus', 'blur'])
+const emit = defineEmits(['focus', 'blur'])
 
 const root = ref(null)
-const filters = reactive({ ...props.modelValue })
 const showPrice = ref(false)
 const activeField = ref(null)
 const priceActive = computed(() => filters.price[0] !== 0 || filters.price[1] !== 1000)
@@ -95,10 +91,6 @@ watch(activeField, (val) => {
     emit('blur')
   }
 })
-
-watch(filters, () => {
-  emit('update:modelValue', { ...filters })
-}, { deep: true })
 
 function onClickOutside(e) {
   if (root.value && !root.value.contains(e.target)) {

--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -16,10 +16,10 @@
 
     <div class="flex-1 flex justify-center px-4">
       <FilterBar
-        v-model="filters"
         class="w-full max-w-xl"
         :expanded="searchActive"
         @focus="searchActive = true"
+        @blur="searchActive = false"
       />
     </div>
 
@@ -66,7 +66,6 @@ import { onAuthStateChanged, signOut } from 'firebase/auth'
 // Overlay-Menü-Komponente
 import OverlayMenu from '@/components/common/OverlayMenu.vue'
 import FilterBar from '@/components/user/FilterBar.vue'
-import { filters } from '@/stores/filters'
 
 const db = getFirestore()
 const router = useRouter()


### PR DESCRIPTION
## Summary
- remove v-model usage from `FilterBar`
- use global store directly for filter state
- simplify props and emit handling
- adjust `Header` component to new `FilterBar` API

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687904278b708321970af3d17b6a6993