### PR TITLE
Adjust filter bar visibility and size

### DIFF
--- a/src/components/user/FilterBar.vue
+++ b/src/components/user/FilterBar.vue
@@ -1,8 +1,8 @@
 <template>
 <div ref="root" class="sticky top-2 z-30 flex justify-center px-2" @click.self="activeField = null">
     <div
-      class="flex items-center w-full max-w-4xl divide-x rounded-full shadow-lg bg-white/80 backdrop-blur border border-gray-100 transition-all duration-200"
-      :class="{ 'scale-105': expanded }"
+      class="flex items-center w-full max-w-4xl divide-x rounded-full shadow-lg bg-white/80 backdrop-blur border border-gray-100 transition-all duration-200 py-2"
+      :class="{ 'scale-105 py-3': expanded }"
     >
       <div
         class="relative flex items-center gap-2 px-4 flex-1 transition-all duration-200"

--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -14,9 +14,9 @@
 
     <nav class="hidden md:flex items-center gap-6 text-sm font-medium"></nav>
 
-    <div class="flex-1 flex justify-center px-4">
+    <div class="flex-1 flex justify-center px-4" v-if="showFilterBar">
       <FilterBar
-        class="w-full max-w-xl"
+        class="w-full max-w-2xl"
         :expanded="searchActive"
         @focus="searchActive = true"
         @blur="searchActive = false"
@@ -57,8 +57,8 @@
 
 <script setup>
 // Reaktives State-Management und Lifecycle-Hooks
-import { ref, onMounted, onBeforeUnmount } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 // Firebase-Dienste
 import { auth } from '@/firebase'
 import { doc, getDoc, getFirestore } from 'firebase/firestore'
@@ -69,6 +69,9 @@ import FilterBar from '@/components/user/FilterBar.vue'
 
 const db = getFirestore()
 const router = useRouter()
+const route = useRoute()
+
+const showFilterBar = computed(() => route.name === 'home')
 // steuert die Sichtbarkeit des Menüs
 const showOverlay = ref(false)
 // Daten des eingelog gten Unternehmens


### PR DESCRIPTION
## Summary
- show the search filter bar only on the home page
- make the bar slightly larger when collapsed and expanded

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687905b42810832184ba099732602a89