### PR TITLE
Fix HomeView open hours and remove debug logs

### DIFF
--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -62,6 +62,8 @@ onMounted(async () => {
   }
 })
 
+const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
+
 // Filterlogik für die Ergebnissliste
 const filteredCompanies = computed(() => {
   const now = new Date()
@@ -73,12 +75,15 @@ const filteredCompanies = computed(() => {
     let isOpen = true
     if (filters.openNow) {
       try {
-        const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
-        const today = days[now.getDay() - 1]
+        let dayIndex = now.getDay() - 1
+        if (dayIndex < 0) dayIndex = 6
+        const today = days[dayIndex]
         const hours = company.opening_hours?.[today]
         if (hours?.open && hours?.close) {
-          const openM = parseInt(hours.open.split(':')[0]) * 60 + parseInt(hours.open.split(':')[1])
-          const closeM = parseInt(hours.close.split(':')[0]) * 60 + parseInt(hours.close.split(':')[1])
+          const [oh, om] = hours.open.split(':').map(Number)
+          const [ch, cm] = hours.close.split(':').map(Number)
+          const openM = oh * 60 + om
+          const closeM = ch * 60 + cm
           isOpen = currentMinutes >= openM && currentMinutes <= closeM
         } else {
           isOpen = false

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -2,7 +2,6 @@ import { storage, auth } from '@/firebase'
 import { ref as storageRef, uploadBytes, getDownloadURL } from 'firebase/storage'
 
 export async function uploadCompanyLogo(file) {
-  console.log('Upload startet, User:', auth.currentUser)
   if (!auth.currentUser) {
     throw new Error('Nicht angemeldet')
   }
@@ -11,7 +10,6 @@ export async function uploadCompanyLogo(file) {
   const imgRef = storageRef(storage, path)
   await uploadBytes(imgRef, file)
   const url = await getDownloadURL(imgRef)
-  console.log('Upload abgeschlossen, URL:', url)
   return url
 }
 


### PR DESCRIPTION
## Summary
- account for Sunday when checking open hours on the home page
- reuse constant days array in HomeView filter logic
- remove leftover debug logging from `uploadCompanyLogo`

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6879090d41748321b6e09439f0ac4b2a