### PR TITLE
Improve mobile search layout

### DIFF
--- a/src/components/user/FilterBar.vue
+++ b/src/components/user/FilterBar.vue
@@ -1,11 +1,11 @@
 <template>
 <div ref="root" class="sticky top-2 z-30 flex justify-center px-2" @click.self="activeField = null">
     <div
-      class="flex items-center w-full max-w-4xl divide-x rounded-full shadow-lg bg-white/80 backdrop-blur border border-gray-100 transition-all duration-200 py-2 overflow-hidden"
+      class="flex flex-col sm:flex-row items-center w-full max-w-4xl divide-y sm:divide-x rounded-xl shadow-lg bg-white/80 backdrop-blur border border-gray-100 transition-all duration-200 py-2 overflow-hidden"
       :class="{ 'scale-105 py-3': expanded }"
     >
       <div
-        class="relative flex items-center gap-2 px-4 flex-1 transition-all duration-200"
+        class="relative flex items-center gap-2 px-4 flex-1 transition-all duration-200 w-full"
         :class="{ 'bg-white scale-105 z-10': activeField === 'location' || filters.location }"
         @click.stop="activeField = 'location'"
       >
@@ -27,7 +27,7 @@
         <!-- Input field for location, suggestions removed as free input is desired -->
       </div>
       <button
-        class="relative flex items-center gap-2 px-4 flex-shrink-0 hover:bg-gray-50 transition-all duration-200"
+        class="relative flex items-center gap-2 px-4 flex-shrink-0 hover:bg-gray-50 transition-all duration-200 w-full sm:w-auto"
         :class="{ 'text-gold bg-white scale-105 z-10': activeField === 'openNow' || filters.openNow }"
         @click.stop="toggle('openNow'); activeField = 'openNow'"
       >
@@ -38,7 +38,7 @@
         </span>
       </button>
       <button
-        class="relative flex items-center gap-2 px-4 flex-shrink-0 hover:bg-gray-50 transition-all duration-200"
+        class="relative flex items-center gap-2 px-4 flex-shrink-0 hover:bg-gray-50 transition-all duration-200 w-full sm:w-auto"
         :class="{ 'text-gold bg-white scale-105 z-10': activeField === 'price' || priceActive }"
         @click.stop="openPrice"
       >
@@ -50,7 +50,7 @@
         </span>
         <ChevronDown v-else class="w-4 h-4" />
       </button>
-      <div class="pl-3 pr-4">
+      <div class="pl-4 pr-4 w-full sm:w-auto flex justify-end">
         <button class="p-2 bg-gold rounded-full text-white hover:bg-gold/90" aria-label="Suchen">
           <Search class="w-4 h-4" />
         </button>

--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -7,6 +7,7 @@
     <router-link
       to="/"
       class="flex items-center gap-2 px-3 py-2 rounded-lg border border-transparent hover:border-gold/50 hover:bg-gold/5 transition-colors"
+      v-show="!isMobile"
     >
       <img src="/logo.png" alt="Logo" class="h-12 w-auto" />
       <span class="font-bold text-xl text-gold">Magikey</span>
@@ -18,10 +19,11 @@
       <button
         v-if="isMobile && !searchActive"
         @click="searchActive = true"
-        class="p-2 text-xl text-gray-700"
+        class="flex items-center justify-between w-full px-4 py-3 rounded-full border border-gray-300 bg-white shadow text-gray-700"
         aria-label="Suche öffnen"
       >
-        <Search class="w-6 h-6" />
+        <span class="text-sm">Suche</span>
+        <Search class="w-5 h-5" />
       </button>
       <transition name="slide-down">
         <FilterBar
@@ -36,13 +38,13 @@
 
     <div class="flex items-center gap-3">
       <!-- Link zum Dashboard wenn Firma eingeloggt ist -->
-      <router-link v-if="companyData" to="/dashboard" class="flex items-center gap-2 hover:underline">
+      <router-link v-if="companyData" to="/dashboard" class="flex items-center gap-2 hover:underline" v-show="!isMobile">
         <img :src="companyData.logo_url || '/logo.png'" alt="Logo" class="w-9 h-9 rounded-full object-cover" />
         <span class="font-medium">{{ companyData.company_name }}</span>
       </router-link>
 
       <template v-if="!companyData">
-        <router-link to="/register" class="btn-outline hidden md:inline-flex items-center">
+        <router-link to="/register" class="btn-outline hidden md:inline-flex items-center" v-show="!isMobile">
           <i class="fa fa-key mr-2 animate-bounce"></i>
           Werde Problemsolver:in
         </router-link>


### PR DESCRIPTION
## Summary
- update Header mobile behaviour so only burger menu and search button are visible
- show a wide search button on mobile
- stack filter options vertically on small screens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879132854e88321a9f6606f420dce70