### PR TITLE
Fix mobile header visibility

### DIFF
--- a/src/components/user/FilterBar.vue
+++ b/src/components/user/FilterBar.vue
@@ -1,11 +1,11 @@
 <template>
 <div ref="root" class="sticky top-2 z-30 flex justify-center px-2" @click.self="activeField = null">
     <div
-      class="flex flex-col sm:flex-row items-center w-full max-w-4xl divide-y sm:divide-x rounded-xl shadow-lg bg-white/80 backdrop-blur border border-gray-100 transition-all duration-200 py-2 overflow-hidden"
+      class="flex flex-col sm:flex-row items-center w-full max-w-4xl divide-y sm:divide-x rounded-xl shadow-lg bg-white/80 backdrop-blur border border-gray-100 transition-all duration-200 py-3 sm:py-2 text-base sm:text-sm overflow-hidden"
       :class="{ 'scale-105 py-3': expanded }"
     >
       <div
-        class="relative flex items-center gap-2 px-4 flex-1 transition-all duration-200 w-full"
+        class="relative flex items-center gap-2 px-4 flex-1 transition-all duration-200 w-full py-3 sm:py-2"
         :class="{ 'bg-white scale-105 z-10': activeField === 'location' || filters.location }"
         @click.stop="activeField = 'location'"
       >
@@ -13,7 +13,7 @@
         <input
           v-model="filters.location"
           placeholder="Wo?"
-          class="flex-1 bg-transparent border-none focus:ring-0 placeholder:text-gray-400 text-sm"
+          class="flex-1 bg-transparent border-none focus:ring-0 placeholder:text-gray-400 text-base sm:text-sm"
           autocomplete="postal-code"
           @focus="activeField = 'location'"
         />
@@ -27,7 +27,7 @@
         <!-- Input field for location, suggestions removed as free input is desired -->
       </div>
       <button
-        class="relative flex items-center gap-2 px-4 flex-shrink-0 hover:bg-gray-50 transition-all duration-200 w-full sm:w-auto"
+        class="relative flex items-center gap-2 px-4 flex-shrink-0 hover:bg-gray-50 transition-all duration-200 w-full sm:w-auto py-3 sm:py-2 text-base sm:text-sm"
         :class="{ 'text-gold bg-white scale-105 z-10': activeField === 'openNow' || filters.openNow }"
         @click.stop="toggle('openNow'); activeField = 'openNow'"
       >
@@ -38,7 +38,7 @@
         </span>
       </button>
       <button
-        class="relative flex items-center gap-2 px-4 flex-shrink-0 hover:bg-gray-50 transition-all duration-200 w-full sm:w-auto"
+        class="relative flex items-center gap-2 px-4 flex-shrink-0 hover:bg-gray-50 transition-all duration-200 w-full sm:w-auto py-3 sm:py-2 text-base sm:text-sm"
         :class="{ 'text-gold bg-white scale-105 z-10': activeField === 'price' || priceActive }"
         @click.stop="openPrice"
       >
@@ -50,7 +50,7 @@
         </span>
         <ChevronDown v-else class="w-4 h-4" />
       </button>
-      <div class="pl-4 pr-4 w-full sm:w-auto flex justify-end">
+      <div class="pl-4 pr-4 w-full sm:w-auto flex justify-end py-3 sm:py-0">
         <button class="p-2 bg-gold rounded-full text-white hover:bg-gold/90" aria-label="Suchen">
           <Search class="w-4 h-4" />
         </button>

--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -4,11 +4,11 @@
     class="fixed top-0 left-0 w-full z-50 bg-gray-100/90 backdrop-blur border-b border-gray-200 text-gray-900 px-6 py-4 shadow-sm flex items-center justify-between relative transition-all duration-200"
     :class="{ 'py-6': searchActive }"
   >
-    <router-link
-      to="/"
-      class="flex items-center gap-2 px-3 py-2 rounded-lg border border-transparent hover:border-gold/50 hover:bg-gold/5 transition-colors"
-      v-show="!isMobile"
-    >
+      <router-link
+        to="/"
+        class="flex items-center gap-2 px-3 py-2 rounded-lg border border-transparent hover:border-gold/50 hover:bg-gold/5 transition-colors"
+        v-show="!hideNavOnHomeMobile"
+      >
       <img src="/logo.png" alt="Logo" class="h-12 w-auto" />
       <span class="font-bold text-xl text-gold">Magikey</span>
     </router-link>
@@ -38,13 +38,13 @@
 
     <div class="flex items-center gap-3">
       <!-- Link zum Dashboard wenn Firma eingeloggt ist -->
-      <router-link v-if="companyData" to="/dashboard" class="flex items-center gap-2 hover:underline" v-show="!isMobile">
+      <router-link v-if="companyData" to="/dashboard" class="flex items-center gap-2 hover:underline" v-show="!hideNavOnHomeMobile">
         <img :src="companyData.logo_url || '/logo.png'" alt="Logo" class="w-9 h-9 rounded-full object-cover" />
         <span class="font-medium">{{ companyData.company_name }}</span>
       </router-link>
 
       <template v-if="!companyData">
-        <router-link to="/register" class="btn-outline hidden md:inline-flex items-center" v-show="!isMobile">
+        <router-link to="/register" class="btn-outline hidden md:inline-flex items-center" v-show="!hideNavOnHomeMobile">
           <i class="fa fa-key mr-2 animate-bounce"></i>
           Werde Problemsolver:in
         </router-link>
@@ -86,6 +86,8 @@ const router = useRouter()
 const route = useRoute()
 
 const showFilterBar = computed(() => route.name === 'home')
+const isMobile = ref(false)
+const hideNavOnHomeMobile = computed(() => isMobile.value && route.name === 'home')
 // steuert die Sichtbarkeit des Menüs
 const showOverlay = ref(false)
 // Daten des eingelog gten Unternehmens
@@ -95,8 +97,6 @@ const menuButton = ref(null)
 // zeigt an, ob die Suchleiste aktiv ist
 const searchActive = ref(false)
 // zeigt, ob die Ansicht mobil ist
-const isMobile = ref(false)
-
 // Menü ein- oder ausblenden
 function toggleOverlay() {
   showOverlay.value = !showOverlay.value


### PR DESCRIPTION
## Summary
- update FilterBar spacing for bigger stacked mobile layout
- hide logo/register links on mobile only on the home route

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687914d264248321a0dd06034903d847