### PR TITLE
Improve mobile filter experience

### DIFF
--- a/src/components/user/FilterBar.vue
+++ b/src/components/user/FilterBar.vue
@@ -128,4 +128,6 @@ function closePrice() {
   showPrice.value = false
   activeField.value = null
 }
+
+defineExpose({ openPrice })
 </script>

--- a/src/components/user/MobileFilterBar.vue
+++ b/src/components/user/MobileFilterBar.vue
@@ -1,0 +1,75 @@
+<template>
+  <div ref="root" class="sm:hidden flex justify-center px-2 sticky top-2 z-30">
+    <div v-if="!expanded" class="flex items-center w-full max-w-4xl gap-2">
+      <button @click="expanded = true" class="flex-1 flex items-center justify-between px-4 py-3 rounded-full border shadow bg-white">
+        <span class="text-sm">Suche</span>
+        <Search class="w-5 h-5" />
+      </button>
+      <button @click="toggle('openNow')" class="p-3 rounded-full border bg-white" :class="{ 'text-gold border-gold': filters.openNow }">
+        <Clock class="w-5 h-5" />
+      </button>
+      <button @click="openPrice" class="p-3 rounded-full border bg-white" :class="{ 'text-gold border-gold': priceActive }">
+        <Euro class="w-5 h-5" />
+      </button>
+    </div>
+    <transition name="slide-down">
+      <FilterBar
+        ref="bar"
+        v-show="expanded"
+        class="w-full max-w-2xl"
+        :expanded="true"
+        @blur="expanded = false"
+      />
+    </transition>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import { Search, Clock, Euro } from '@/components/icons'
+import FilterBar from './FilterBar.vue'
+import { filters } from '@/stores/filters'
+
+const expanded = ref(false)
+const bar = ref(null)
+const root = ref(null)
+
+const priceActive = computed(() => filters.price[0] !== 0 || filters.price[1] !== 1000)
+
+function toggle(key) {
+  filters[key] = !filters[key]
+}
+
+function openPrice() {
+  expanded.value = true
+  nextTick(() => {
+    bar.value?.openPrice()
+  })
+}
+
+function handleClickOutside(e) {
+  if (root.value && !root.value.contains(e.target)) {
+    expanded.value = false
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
+</script>
+
+<style scoped>
+.slide-down-enter-from,
+.slide-down-leave-to {
+  opacity: 0;
+  transform: translateY(-0.75rem);
+}
+.slide-down-enter-active,
+.slide-down-leave-active {
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+</style>

--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -16,18 +16,10 @@
     <nav class="hidden md:flex items-center gap-6 text-sm font-medium"></nav>
 
     <div class="flex-1 flex justify-center px-4" v-if="showFilterBar">
-      <button
-        v-if="isMobile && !searchActive"
-        @click="searchActive = true"
-        class="flex items-center justify-between w-full px-4 py-3 rounded-full border border-gray-300 bg-white shadow text-gray-700"
-        aria-label="Suche öffnen"
-      >
-        <span class="text-sm">Suche</span>
-        <Search class="w-5 h-5" />
-      </button>
+      <MobileFilterBar v-if="isMobile" />
       <transition name="slide-down">
         <FilterBar
-          v-show="!isMobile || searchActive"
+          v-show="!isMobile"
           class="w-full max-w-2xl"
           :expanded="searchActive"
           @focus="searchActive = true"
@@ -79,7 +71,7 @@ import { onAuthStateChanged, signOut } from 'firebase/auth'
 // Overlay-Menü-Komponente
 import OverlayMenu from '@/components/common/OverlayMenu.vue'
 import FilterBar from '@/components/user/FilterBar.vue'
-import { Search } from '@/components/icons'
+import MobileFilterBar from '@/components/user/MobileFilterBar.vue'
 
 const db = getFirestore()
 const router = useRouter()


### PR DESCRIPTION
## Summary
- add new `MobileFilterBar` component for phones
- expose `openPrice` method in `FilterBar` so mobile menu can trigger the price sheet
- update header to use the new mobile filter

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879184580548321b2bac9e2d4e05775