### PR TITLE
feat: enhance mobile filter bar UX

### DIFF
--- a/src/components/user/MobileFilterBar.vue
+++ b/src/components/user/MobileFilterBar.vue
@@ -1,20 +1,18 @@
 <template>
   <div ref="root" class="sm:hidden flex justify-center px-2 sticky top-2 z-30">
-    <div v-if="!expanded" class="flex items-center w-full max-w-4xl gap-2">
-      <button @click="expanded = true" class="flex-1 flex items-center justify-between px-4 py-3 rounded-full border shadow bg-white">
-        <span class="text-sm">Suche</span>
-        <Search class="w-5 h-5" />
-      </button>
-      <button @click="toggle('openNow')" class="p-3 rounded-full border bg-white" :class="{ 'text-gold border-gold': filters.openNow }">
-        <Clock class="w-5 h-5" />
-      </button>
-      <button @click="openPrice" class="p-3 rounded-full border bg-white" :class="{ 'text-gold border-gold': priceActive }">
-        <Euro class="w-5 h-5" />
+    <div v-if="!expanded" class="w-full max-w-4xl">
+      <button
+        @click="expanded = true"
+        class="w-full flex items-center gap-2 px-6 py-4 rounded-full border shadow bg-white"
+      >
+        <Search class="w-5 h-5 text-gold" />
+        <span class="text-sm text-gray-600">
+          {{ filters.location || 'Ort, Preis, Öffnungszeiten…' }}
+        </span>
       </button>
     </div>
     <transition name="slide-down">
       <FilterBar
-        ref="bar"
         v-show="expanded"
         class="w-full max-w-2xl"
         :expanded="true"
@@ -25,27 +23,13 @@
 </template>
 
 <script setup>
-import { ref, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
-import { Search, Clock, Euro } from '@/components/icons'
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { Search } from '@/components/icons'
 import FilterBar from './FilterBar.vue'
 import { filters } from '@/stores/filters'
 
 const expanded = ref(false)
-const bar = ref(null)
 const root = ref(null)
-
-const priceActive = computed(() => filters.price[0] !== 0 || filters.price[1] !== 1000)
-
-function toggle(key) {
-  filters[key] = !filters[key]
-}
-
-function openPrice() {
-  expanded.value = true
-  nextTick(() => {
-    bar.value?.openPrice()
-  })
-}
 
 function handleClickOutside(e) {
   if (root.value && !root.value.contains(e.target)) {


### PR DESCRIPTION
## Summary
- refine mobile filter bar to show a single prominent search button
- expand full filter panel from top when activated

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c868523b0832189ea5633066ef642