### PR TITLE
refactor filtering logic and add lazy loading

### DIFF
--- a/src/components/user/FilterBar.vue
+++ b/src/components/user/FilterBar.vue
@@ -1,74 +1,70 @@
 <template>
-<div ref="root" class="sticky top-2 z-30 flex justify-center px-2" @click.self="activeField = null">
+  <div ref="root" class="sticky top-2 z-30 flex justify-center px-2" @click.self="activeField = null">
     <div
-      class="flex items-center w-full max-w-4xl divide-x rounded-full shadow-lg bg-white/80 backdrop-blur border border-gray-100 transition-all duration-200 py-3 sm:py-2 text-base sm:text-sm overflow-hidden"
+      class="flex w-full max-w-4xl items-center divide-x overflow-hidden rounded-full border border-gray-100 bg-white/80 px-4 py-3 text-base shadow-lg backdrop-blur transition-all duration-200 sm:py-2 sm:text-sm"
       :class="{ 'scale-105 py-3': expanded }"
     >
       <div
-        class="relative flex items-center gap-2 px-4 flex-1 transition-all duration-200 py-3 sm:py-2"
-        :class="{ 'bg-white scale-105 z-10': activeField === 'location' || filters.location }"
+        class="relative flex flex-1 items-center gap-2 py-3 px-4 transition-all duration-200 sm:py-2"
+        :class="{ 'z-10 scale-105 bg-white': activeField === 'location' || filters.location }"
         @click.stop="activeField = 'location'"
       >
-        <MapPin class="w-5 h-5 text-gold" />
+        <MapPin class="h-5 w-5 text-gold" />
         <input
           v-model="filters.location"
           placeholder="Wo?"
-          class="flex-1 bg-transparent border-none focus:ring-0 placeholder:text-gray-400 text-base sm:text-sm"
+          class="flex-1 border-none bg-transparent text-base placeholder:text-gray-400 focus:ring-0 sm:text-sm"
           autocomplete="postal-code"
           @focus="activeField = 'location'"
         />
         <button
           v-if="filters.location"
-          @click.stop="clear('location')"
+          @click.stop="clearFilter('location')"
           class="text-gray-400 hover:text-black"
         >
-          <X class="w-3 h-3" />
+          <X class="h-3 w-3" />
         </button>
-        <!-- Input field for location, suggestions removed as free input is desired -->
       </div>
       <button
-        class="relative flex items-center gap-2 px-4 flex-shrink-0 hover:bg-gray-50 transition-all duration-200 py-3 sm:py-2 text-base sm:text-sm"
-        :class="{ 'text-gold bg-white scale-105 z-10': activeField === 'openNow' || filters.openNow }"
-        @click.stop="toggle('openNow'); activeField = 'openNow'"
+        class="relative flex flex-shrink-0 items-center gap-2 py-3 px-4 text-base transition-all duration-200 hover:bg-gray-50 sm:py-2 sm:text-sm"
+        :class="{ 'z-10 scale-105 bg-white text-gold': activeField === 'openNow' || filters.openNow }"
+        @click.stop="toggleFilter('openNow'); activeField = 'openNow'"
       >
-        <Clock class="w-5 h-5" />
+        <Clock class="h-5 w-5" />
         <span class="hidden sm:inline">Jetzt geöffnet</span>
-        <span v-if="filters.openNow" @click.stop="clear('openNow')" class="ml-1 text-gray-400 hover:text-black cursor-pointer">
-          <X class="w-3 h-3" />
+        <span v-if="filters.openNow" @click.stop="clearFilter('openNow')" class="ml-1 cursor-pointer text-gray-400 hover:text-black">
+          <X class="h-3 w-3" />
         </span>
       </button>
       <button
-        class="relative flex items-center gap-2 px-4 flex-shrink-0 hover:bg-gray-50 transition-all duration-200 py-3 sm:py-2 text-base sm:text-sm"
-        :class="{ 'text-gold bg-white scale-105 z-10': activeField === 'price' || priceActive }"
+        class="relative flex flex-shrink-0 items-center gap-2 py-3 px-4 text-base transition-all duration-200 hover:bg-gray-50 sm:py-2 sm:text-sm"
+        :class="{ 'z-10 scale-105 bg-white text-gold': activeField === 'price' || priceActive }"
         @click.stop="openPrice"
       >
-        <Euro class="w-5 h-5" />
+        <Euro class="h-5 w-5" />
         <span class="hidden sm:inline" v-if="!priceActive">Preis</span>
         <span class="hidden sm:inline" v-else>{{ filters.price[0] }}€ - {{ filters.price[1] }}€</span>
-        <span v-if="priceActive" @click.stop="clear('price')" class="ml-1 text-gray-400 hover:text-black cursor-pointer">
-          <X class="w-3 h-3" />
+        <span v-if="priceActive" @click.stop="clearFilter('price')" class="ml-1 cursor-pointer text-gray-400 hover:text-black">
+          <X class="h-3 w-3" />
         </span>
-        <ChevronDown v-else class="w-4 h-4" />
+        <ChevronDown v-else class="h-4 w-4" />
       </button>
-      <div class="pl-4 pr-4 flex justify-end py-3 sm:py-0">
-        <button class="p-2 bg-gold rounded-full text-white hover:bg-gold/90" aria-label="Suchen">
-          <Search class="w-4 h-4" />
+      <div class="flex justify-end py-3 pl-4 pr-4 sm:py-0">
+        <button class="rounded-full bg-gold p-2 text-white hover:bg-gold/90" aria-label="Suchen">
+          <Search class="h-4 w-4" />
         </button>
       </div>
     </div>
-    <FilterPriceSheet
-      v-model="filters.price"
-      :visible="showPrice"
-      @close="closePrice"
-    />
+    <FilterPriceSheet v-model="filters.price" :visible="showPrice" @close="closePrice" />
   </div>
 </template>
 
 <script setup>
-import { ref, watch, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, watch, computed, onMounted, onBeforeUnmount, defineAsyncComponent } from 'vue'
 import { MapPin, Clock, Euro, ChevronDown, Search, X } from '@/components/icons'
-import FilterPriceSheet from './FilterPriceSheet.vue'
-import { filters } from '@/stores/filters'
+import { filters, toggleFilter, clearFilter } from '@/stores/filters'
+
+const FilterPriceSheet = defineAsyncComponent(() => import('./FilterPriceSheet.vue'))
 
 defineProps({
   expanded: {
@@ -105,19 +101,6 @@ onMounted(() => {
 onBeforeUnmount(() => {
   document.removeEventListener('click', onClickOutside)
 })
-
-function toggle(key) {
-  filters[key] = !filters[key]
-}
-function clear(key) {
-  if (key === "price") {
-    filters.price = [0, 1000]
-  } else if (key === "location") {
-    filters.location = ""
-  } else {
-    filters[key] = false
-  }
-}
 
 function openPrice() {
   showPrice.value = true

--- a/src/components/user/MobileFilterBar.vue
+++ b/src/components/user/MobileFilterBar.vue
@@ -1,80 +1,73 @@
 <template>
-  <div ref="root" class="sm:hidden flex justify-center px-2 sticky top-2 z-30">
+  <div ref="root" class="sticky top-2 z-30 flex justify-center px-2 sm:hidden">
     <div class="relative">
       <button
         @click="expanded = !expanded"
-        class="p-3 bg-gold rounded-full text-white shadow-lg focus:outline-none"
+        class="rounded-full bg-gold p-3 text-white shadow-lg focus:outline-none"
         aria-label="Suchen"
       >
-        <Search class="w-5 h-5" />
+        <Search class="h-5 w-5" />
       </button>
       <transition
-        enter-active-class="transition-transform duration-300 origin-top ease-out"
+        enter-active-class="origin-top transition-transform duration-300 ease-out"
         enter-from-class="scale-y-0 opacity-0"
         enter-to-class="scale-y-100 opacity-100"
-        leave-active-class="transition-transform duration-200 origin-top ease-in"
+        leave-active-class="origin-top transition-transform duration-200 ease-in"
         leave-from-class="scale-y-100 opacity-100"
         leave-to-class="scale-y-0 opacity-0"
       >
         <div
           v-if="expanded"
-          class="absolute left-1/2 -translate-x-1/2 mt-2 w-[90vw] max-w-sm bg-white border rounded-xl shadow-lg p-4 space-y-4 z-40"
+          class="absolute left-1/2 z-40 mt-2 w-[90vw] max-w-sm -translate-x-1/2 space-y-4 rounded-xl border bg-white p-4 shadow-lg"
         >
           <div class="flex items-center gap-2">
-            <MapPin class="w-5 h-5 text-gold" />
+            <MapPin class="h-5 w-5 text-gold" />
             <input
               v-model="filters.location"
               placeholder="PLZ"
-              class="flex-1 border rounded px-2 py-1 text-sm focus:outline-none"
+              class="flex-1 rounded border px-2 py-1 text-sm focus:outline-none"
             />
             <button
               v-if="filters.location"
-              @click="clear('location')"
+              @click="clearFilter('location')"
               class="text-gray-400 hover:text-black"
             >
-              <X class="w-3 h-3" />
+              <X class="h-3 w-3" />
             </button>
           </div>
           <div class="flex items-center justify-between">
             <div class="flex items-center gap-2">
-              <Clock class="w-5 h-5 text-gold" />
+              <Clock class="h-5 w-5 text-gold" />
               <span class="text-sm">Jetzt geöffnet</span>
             </div>
-            <input
-              type="checkbox"
-              v-model="filters.openNow"
-              class="form-checkbox h-4 w-4 text-gold"
-            />
+            <input type="checkbox" v-model="filters.openNow" class="h-4 w-4 form-checkbox text-gold" />
           </div>
           <div>
             <button
               @click="openPrice"
-              class="w-full flex items-center justify-between border rounded px-2 py-1 text-sm"
+              class="flex w-full items-center justify-between rounded border px-2 py-1 text-sm"
             >
               <div class="flex items-center gap-2">
-                <Euro class="w-5 h-5 text-gold" />
+                <Euro class="h-5 w-5 text-gold" />
                 <span v-if="!priceActive">Preisauswahl</span>
                 <span v-else>{{ filters.price[0] }}€ - {{ filters.price[1] }}€</span>
               </div>
-              <ChevronDown v-if="!priceActive" class="w-4 h-4 text-gray-500" />
+              <ChevronDown v-if="!priceActive" class="h-4 w-4 text-gray-500" />
             </button>
           </div>
         </div>
       </transition>
     </div>
-    <FilterPriceSheet
-      v-model="filters.price"
-      :visible="showPrice"
-      @close="closePrice"
-    />
+    <FilterPriceSheet v-model="filters.price" :visible="showPrice" @close="closePrice" />
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
+import { ref, onMounted, onBeforeUnmount, computed, defineAsyncComponent } from 'vue'
 import { Search, MapPin, Clock, Euro, ChevronDown, X } from '@/components/icons'
-import FilterPriceSheet from './FilterPriceSheet.vue'
-import { filters } from '@/stores/filters'
+import { filters, clearFilter } from '@/stores/filters'
+
+const FilterPriceSheet = defineAsyncComponent(() => import('./FilterPriceSheet.vue'))
 
 const expanded = ref(false)
 const showPrice = ref(false)
@@ -95,12 +88,6 @@ onMounted(() => {
 onBeforeUnmount(() => {
   document.removeEventListener('click', handleClickOutside)
 })
-
-function clear(key) {
-  if (key === 'location') {
-    filters.location = ''
-  }
-}
 
 function openPrice() {
   showPrice.value = true

--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -1,8 +1,7 @@
 <template>
   <!-- Startseite mit Filterleiste und Firmenliste -->
-  <div class="min-h-screen bg-white px-4 py-6 sm:px-6 max-w-4xl mx-auto">
-
-    <h1 class="text-2xl font-semibold text-center mb-4">Schlüsseldienste in deiner Nähe</h1>
+  <div class="mx-auto max-w-4xl min-h-screen bg-white px-4 py-6 sm:px-6">
+    <h1 class="mb-4 text-center text-2xl font-semibold">Schlüsseldienste in deiner Nähe</h1>
 
     <div>
       <div v-if="loading" class="flex flex-col items-center py-10 text-gray-500">
@@ -17,25 +16,20 @@
         <SearchResults v-else :companies="filteredCompanies" />
       </template>
     </div>
-
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
-// Service zum Abrufen der Firmen
-import { getCompanies } from '@/services/company'
-
+import { onMounted, defineAsyncComponent } from 'vue'
 import SearchResults from '@/components/user/SearchResults.vue'
-import NotifyForm from '@/components/user/NotifyForm.vue'
 import Loader from '@/components/common/Loader.vue'
 import { getPostalFromCoords } from '@/firebase/functions'
 import { filters } from '@/stores/filters'
+import { useCompanyStore } from '@/stores/company'
 
-// Firmenliste und Ladezustand
-const companies = ref([])
-const loading = ref(true)
+const NotifyForm = defineAsyncComponent(() => import('@/components/user/NotifyForm.vue'))
 
+const { loading, fetchCompanies, filteredCompanies } = useCompanyStore()
 
 // Versucht, die Postleitzahl über Geolocation zu ermitteln
 async function useLocation() {
@@ -53,52 +47,6 @@ async function useLocation() {
 // Daten initial laden
 onMounted(async () => {
   useLocation()
-  try {
-    companies.value = await getCompanies()
-  } catch (err) {
-    console.error('Fehler beim Laden:', err)
-  } finally {
-    loading.value = false
-  }
-})
-
-const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
-
-// Filterlogik für die Ergebnissliste
-const filteredCompanies = computed(() => {
-  const now = new Date()
-  const currentMinutes = now.getHours() * 60 + now.getMinutes()
-
-  return companies.value.filter((company) => {
-    const matchesPLZ = company.postal_code?.includes(filters.location)
-
-    let isOpen = true
-    if (filters.openNow) {
-      try {
-        let dayIndex = now.getDay() - 1
-        if (dayIndex < 0) dayIndex = 6
-        const today = days[dayIndex]
-        const hours = company.opening_hours?.[today]
-        if (hours?.open && hours?.close) {
-          const [oh, om] = hours.open.split(':').map(Number)
-          const [ch, cm] = hours.close.split(':').map(Number)
-          const openM = oh * 60 + om
-          const closeM = ch * 60 + cm
-          isOpen = currentMinutes >= openM && currentMinutes <= closeM
-        } else {
-          isOpen = false
-        }
-      } catch (_) {
-        isOpen = false
-      }
-    }
-
-    const price = parseInt(company.price || '0')
-    const inPrice = price >= filters.price[0] && price <= filters.price[1]
-
-    const matchesOpen = !filters.openNow || isOpen
-
-    return matchesPLZ && matchesOpen && inPrice
-  })
+  await fetchCompanies()
 })
 </script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,20 +4,8 @@ import { createRouter, createWebHistory } from 'vue-router'
 // Layout-Komponente
 import DefaultLayout from '@/layouts/DefaultLayout.vue'
 
-// Seitenkomponenten
+// Startseite wird häufig genutzt und bleibt im Hauptbundle
 import HomeView from '@/pages/HomeView.vue'
-import LoginView from '@/pages/company/LoginView.vue'
-import RegisterView from '@/pages/company/RegisterView.vue'
-import DashboardView from '@/pages/company/DashboardView.vue'
-import EditView from '@/pages/company/EditView.vue'
-import CompanyDetailView from '@/pages/user/CompanyDetailView.vue'
-import ImpressumView from '@/pages/ImpressumView.vue'
-import DatenschutzView from '@/pages/DatenschutzView.vue'
-import HelpCenterView from '@/pages/HelpCenterView.vue'
-import SuccessView from '@/pages/SuccessView.vue'
-import VerifyEmailView from '@/pages/VerifyEmailView.vue'
-import ResetPasswordView from '@/pages/ResetPasswordView.vue'
-import NotFoundView from '@/pages/NotFoundView.vue'
 
 // Firebase-Auth-Instanz zum Prüfen von Login-Status
 import { auth } from '@/firebase'
@@ -29,35 +17,35 @@ const routes = [
     component: DefaultLayout,
     children: [
       { path: '', name: 'home', component: HomeView },
-      { path: 'login', name: 'login', component: LoginView },
-      { path: 'register', name: 'register', component: RegisterView },
-      { path: 'reset-password', name: 'reset-password', component: ResetPasswordView },
+      { path: 'login', name: 'login', component: () => import('@/pages/company/LoginView.vue') },
+      { path: 'register', name: 'register', component: () => import('@/pages/company/RegisterView.vue') },
+      { path: 'reset-password', name: 'reset-password', component: () => import('@/pages/ResetPasswordView.vue') },
       {
         path: 'dashboard',
         name: 'dashboard',
-        component: DashboardView,
+        component: () => import('@/pages/company/DashboardView.vue'),
         meta: { requiresAuth: true },
       },
       {
         path: 'edit',
         name: 'edit',
-        component: EditView,
+        component: () => import('@/pages/company/EditView.vue'),
         meta: { requiresAuth: true },
       },
       {
         path: 'details/:id',
         name: 'details',
-        component: CompanyDetailView,
+        component: () => import('@/pages/user/CompanyDetailView.vue'),
         props: true,
       },
-      { path: 'impressum', name: 'impressum', component: ImpressumView },
-      { path: 'datenschutz', name: 'datenschutz', component: DatenschutzView },
-      { path: 'hilfe', name: 'help', component: HelpCenterView },
-      { path: 'success', name: 'success', component: SuccessView },
-      { path: 'verify-email', name: 'verify-email', component: VerifyEmailView },
+      { path: 'impressum', name: 'impressum', component: () => import('@/pages/ImpressumView.vue') },
+      { path: 'datenschutz', name: 'datenschutz', component: () => import('@/pages/DatenschutzView.vue') },
+      { path: 'hilfe', name: 'help', component: () => import('@/pages/HelpCenterView.vue') },
+      { path: 'success', name: 'success', component: () => import('@/pages/SuccessView.vue') },
+      { path: 'verify-email', name: 'verify-email', component: () => import('@/pages/VerifyEmailView.vue') },
     ],
   },
-  { path: '/:pathMatch(.*)*', name: 'not-found', component: NotFoundView },
+  { path: '/:pathMatch(.*)*', name: 'not-found', component: () => import('@/pages/NotFoundView.vue') },
 ]
 
 // Router erstellen

--- a/src/stores/filters.js
+++ b/src/stores/filters.js
@@ -5,3 +5,17 @@ export const filters = reactive({
   price: [0, 1000],
   location: ''
 })
+
+export function toggleFilter(key) {
+  filters[key] = !filters[key]
+}
+
+export function clearFilter(key) {
+  if (key === 'price') {
+    filters.price = [0, 1000]
+  } else if (key === 'location') {
+    filters.location = ''
+  } else {
+    filters[key] = false
+  }
+}


### PR DESCRIPTION
## Summary
- centralize filter actions and add reusable company store
- lazy-load rarely used components and routes for better bundle size
- streamline Tailwind classes and clean up FilterBar implementations

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c904e70a083219e1e70b0b360150d