### PR TITLE
feat: add lock type filters and provider options

### DIFF
--- a/src/components/user/FilterBar.vue
+++ b/src/components/user/FilterBar.vue
@@ -49,6 +49,19 @@
         </span>
         <ChevronDown v-else class="h-4 w-4" />
       </button>
+      <button
+        class="relative flex flex-shrink-0 items-center gap-2 py-3 px-4 text-base transition-all duration-200 hover:bg-gray-50 sm:py-2 sm:text-sm"
+        :class="{ 'z-10 scale-105 bg-white text-gold': activeField === 'lockTypes' || filters.lockTypes.length }"
+        @click.stop="openLockTypes"
+      >
+        <Lock class="h-5 w-5" />
+        <span class="hidden sm:inline" v-if="!filters.lockTypes.length">Schlösser</span>
+        <span class="hidden sm:inline" v-else>{{ filters.lockTypes.length }} ausgewählt</span>
+        <span v-if="filters.lockTypes.length" @click.stop="clearFilter('lockTypes')" class="ml-1 cursor-pointer text-gray-400 hover:text-black">
+          <X class="h-3 w-3" />
+        </span>
+        <ChevronDown v-else class="h-4 w-4" />
+      </button>
       <div class="flex justify-end py-3 pl-4 pr-4 sm:py-0">
         <button class="rounded-full bg-gold p-2 text-white hover:bg-gold/90" aria-label="Suchen">
           <Search class="h-4 w-4" />
@@ -56,15 +69,18 @@
       </div>
     </div>
     <FilterPriceSheet v-model="filters.price" :visible="showPrice" @close="closePrice" />
+    <FilterLockTypeSheet v-model="filters.lockTypes" :visible="showLockTypes" @close="closeLockTypes" />
   </div>
 </template>
 
 <script setup>
 import { ref, watch, computed, onMounted, onBeforeUnmount, defineAsyncComponent } from 'vue'
 import { MapPin, Clock, Euro, ChevronDown, Search, X } from '@/components/icons'
+import { Lock } from 'lucide-vue-next'
 import { filters, toggleFilter, clearFilter } from '@/stores/filters'
 
 const FilterPriceSheet = defineAsyncComponent(() => import('./FilterPriceSheet.vue'))
+const FilterLockTypeSheet = defineAsyncComponent(() => import('./FilterLockTypeSheet.vue'))
 
 defineProps({
   expanded: {
@@ -77,6 +93,7 @@ const emit = defineEmits(['focus', 'blur'])
 
 const root = ref(null)
 const showPrice = ref(false)
+const showLockTypes = ref(false)
 const activeField = ref(null)
 const priceActive = computed(() => filters.price[0] !== 0 || filters.price[1] !== 1000)
 
@@ -109,6 +126,16 @@ function openPrice() {
 
 function closePrice() {
   showPrice.value = false
+  activeField.value = null
+}
+
+function openLockTypes() {
+  showLockTypes.value = true
+  activeField.value = 'lockTypes'
+}
+
+function closeLockTypes() {
+  showLockTypes.value = false
   activeField.value = null
 }
 

--- a/src/components/user/FilterLockTypeSheet.vue
+++ b/src/components/user/FilterLockTypeSheet.vue
@@ -1,0 +1,54 @@
+<template>
+  <teleport to="body">
+    <transition name="fade">
+      <div v-if="visible" class="fixed inset-0 bg-black/50 z-40 flex items-end sm:items-center justify-center">
+        <div class="bg-white w-full sm:max-w-sm rounded-t-2xl sm:rounded-2xl p-4">
+          <div class="flex justify-between items-center mb-4">
+            <h3 class="text-lg font-semibold">Schlosstypen</h3>
+            <button @click="close" class="text-gray-500 hover:text-black">
+              <X class="w-5 h-5" />
+            </button>
+          </div>
+          <div class="space-y-2 max-h-60 overflow-auto">
+            <label v-for="opt in options" :key="opt.value" class="flex items-center gap-2 text-sm">
+              <input type="checkbox" :value="opt.value" v-model="selected" class="accent-gold" />
+              <span>{{ opt.label }}</span>
+            </label>
+          </div>
+          <div class="text-right mt-4">
+            <button class="btn px-4 py-2" @click="apply">Übernehmen</button>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </teleport>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { X } from 'lucide-vue-next'
+import { LOCK_TYPE_OPTIONS } from '@/constants/lockTypes'
+
+const props = defineProps({
+  modelValue: { type: Array, default: () => [] },
+  visible: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['update:modelValue', 'close'])
+
+const options = LOCK_TYPE_OPTIONS
+const selected = ref([...props.modelValue])
+
+watch(() => props.modelValue, (val) => {
+  selected.value = [...val]
+})
+
+function apply() {
+  emit('update:modelValue', selected.value)
+  close()
+}
+
+function close() {
+  emit('close')
+}
+</script>

--- a/src/components/user/MobileFilterBar.vue
+++ b/src/components/user/MobileFilterBar.vue
@@ -55,22 +55,39 @@
               <ChevronDown v-if="!priceActive" class="h-4 w-4 text-gray-500" />
             </button>
           </div>
+          <div>
+            <button
+              @click="openLockTypes"
+              class="flex w-full items-center justify-between rounded border px-2 py-1 text-sm mt-2"
+            >
+              <div class="flex items-center gap-2">
+                <Lock class="h-5 w-5 text-gold" />
+                <span v-if="!filters.lockTypes.length">Schlösser</span>
+                <span v-else>{{ filters.lockTypes.length }} ausgewählt</span>
+              </div>
+              <ChevronDown v-if="!filters.lockTypes.length" class="h-4 w-4 text-gray-500" />
+            </button>
+          </div>
         </div>
       </transition>
     </div>
     <FilterPriceSheet v-model="filters.price" :visible="showPrice" @close="closePrice" />
+    <FilterLockTypeSheet v-model="filters.lockTypes" :visible="showLockTypes" @close="closeLockTypes" />
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted, onBeforeUnmount, computed, defineAsyncComponent } from 'vue'
 import { Search, MapPin, Clock, Euro, ChevronDown, X } from '@/components/icons'
+import { Lock } from 'lucide-vue-next'
 import { filters, clearFilter } from '@/stores/filters'
 
 const FilterPriceSheet = defineAsyncComponent(() => import('./FilterPriceSheet.vue'))
+const FilterLockTypeSheet = defineAsyncComponent(() => import('./FilterLockTypeSheet.vue'))
 
 const expanded = ref(false)
 const showPrice = ref(false)
+const showLockTypes = ref(false)
 const root = ref(null)
 
 const priceActive = computed(() => filters.price[0] !== 0 || filters.price[1] !== 1000)
@@ -95,6 +112,14 @@ function openPrice() {
 
 function closePrice() {
   showPrice.value = false
+}
+
+function openLockTypes() {
+  showLockTypes.value = true
+}
+
+function closeLockTypes() {
+  showLockTypes.value = false
 }
 </script>
 

--- a/src/components/user/SearchResultTile.vue
+++ b/src/components/user/SearchResultTile.vue
@@ -28,6 +28,9 @@
           {{ openStatus }}
         </span>
       </p>
+      <p v-if="lockTypeLabels.length" class="text-xs text-gray-500">
+        Kompatibel mit: {{ lockTypeLabels.join(', ') }}
+      </p>
     </div>
   </li>
 </template>
@@ -35,6 +38,7 @@
 <script setup>
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { LOCK_TYPE_LABELS } from '@/constants/lockTypes'
 
 const props = defineProps({
   company: {
@@ -79,6 +83,10 @@ const statusClass = computed(() =>
 
 const borderColor = computed(() =>
   isOpen.value ? 'border-green-500' : props.company.is_247 ? 'border-red-500' : 'border-gray-300'
+)
+
+const lockTypeLabels = computed(() =>
+  (props.company.lock_types || []).map((t) => LOCK_TYPE_LABELS[t] || t)
 )
 
 function navigateToDetails() {

--- a/src/constants/lockTypes.js
+++ b/src/constants/lockTypes.js
@@ -1,0 +1,13 @@
+export const LOCK_TYPE_OPTIONS = [
+  { value: 'house', label: 'Haustür / Wohnungstür' },
+  { value: 'car_mechanical', label: 'Auto (mechanisch)' },
+  { value: 'car_electronic', label: 'Auto (elektronisch / Wegfahrsperre)' },
+  { value: 'bike', label: 'Fahrradschloss' },
+  { value: 'padlock', label: 'Vorhängeschloss' },
+  { value: 'safe', label: 'Tresor' },
+  { value: 'smart', label: 'Bluetooth-/Smartlock' },
+  { value: 'mailbox', label: 'Briefkasten' },
+  { value: 'other', label: 'Sonstiges' }
+]
+
+export const LOCK_TYPE_LABELS = Object.fromEntries(LOCK_TYPE_OPTIONS.map(o => [o.value, o.label]))

--- a/src/pages/company/EditView.vue
+++ b/src/pages/company/EditView.vue
@@ -86,6 +86,16 @@
           :classes="{ label: 'label', input: 'textarea' }"
         />
 
+        <div>
+          <label class="label">Schlosstypen</label>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <label v-for="opt in lockTypeOptions" :key="opt.value" class="flex items-center gap-2 text-sm">
+              <input type="checkbox" :value="opt.value" v-model="company.lock_types" class="accent-gold" />
+              <span>{{ opt.label }}</span>
+            </label>
+          </div>
+        </div>
+
         <OpeningHoursForm v-model="company.opening_hours" />
 
 
@@ -131,6 +141,7 @@ import CompanyImageUpload from '@/components/company/CompanyImageUpload.vue'
 import Button from '@/components/common/Button.vue'
 import OpeningHoursForm from '@/components/company/OpeningHoursForm.vue'
 import { sendVerificationEmail } from '@/services/auth'
+import { LOCK_TYPE_OPTIONS } from '@/constants/lockTypes'
 
 const router = useRouter()
 const user = auth.currentUser
@@ -152,6 +163,7 @@ const company = ref({
   is_247: false,
   emergency_price: '',
   opening_hours: {},
+  lock_types: [],
 })
 
 onMounted(async () => {
@@ -161,6 +173,8 @@ onMounted(async () => {
     company.value = { ...company.value, ...docSnap.data() }
   }
 })
+
+const lockTypeOptions = LOCK_TYPE_OPTIONS
 
 const saveChanges = async () => {
   if (!user || logoUploading.value) {

--- a/src/pages/company/RegisterView.vue
+++ b/src/pages/company/RegisterView.vue
@@ -127,6 +127,16 @@
           :classes="{ label: 'label', input: 'textarea' }"
         />
 
+        <div>
+          <label class="label">Schlosstypen</label>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <label v-for="opt in lockTypeOptions" :key="opt.value" class="flex items-center gap-2 text-sm">
+              <input type="checkbox" :value="opt.value" v-model="lockTypes" class="accent-gold" />
+              <span>{{ opt.label }}</span>
+            </label>
+          </div>
+        </div>
+
         <OpeningHoursForm v-model="openingHours" />
 
 
@@ -164,12 +174,15 @@ import { loginWithGoogle } from '@/services/auth'
 import Button from '@/components/common/Button.vue'
 import OpeningHoursForm from '@/components/company/OpeningHoursForm.vue'
 import Loader from '@/components/common/Loader.vue'
+import { LOCK_TYPE_OPTIONS } from '@/constants/lockTypes'
 
 const router = useRouter()
 const is247 = ref(false)
 const googleLoading = ref(false)
 const googleError = ref('')
 const openingHours = ref({})
+const lockTypes = ref([])
+const lockTypeOptions = LOCK_TYPE_OPTIONS
 
 
 const register = async (form) => {
@@ -188,6 +201,7 @@ const register = async (form) => {
       postal_code: form.postal_code || '',
       price: form.price || '',
       description: form.description || '',
+      lock_types: lockTypes.value,
       opening_hours: openingHours.value,
       is_247: form.is_247 || false,
       emergency_price: form.is_247 ? form.emergency_price || '' : '',

--- a/src/pages/user/CompanyDetailView.vue
+++ b/src/pages/user/CompanyDetailView.vue
@@ -45,6 +45,19 @@
           <p class="text-gray-700">{{ company.description || 'Keine Beschreibung' }}</p>
         </div>
 
+        <div v-if="lockTypeLabels.length" class="mt-6">
+          <h2 class="font-semibold mb-2 text-black">Kompatible Schlösser</h2>
+          <div class="flex flex-wrap gap-2">
+            <span
+              v-for="t in lockTypeLabels"
+              :key="t"
+              class="bg-gray-100 text-gray-800 text-xs px-2 py-1 rounded-full"
+            >
+              {{ t }}
+            </span>
+          </div>
+        </div>
+
         <div class="mt-8 flex gap-4 justify-center">
           <a
             v-if="company.phone"
@@ -76,6 +89,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { getCompany } from '@/services/company'
 import DataRow from '@/components/common/DataRow.vue'
+import { LOCK_TYPE_LABELS } from '@/constants/lockTypes'
 
 const route = useRoute()
 const companyId = route.params.id
@@ -149,4 +163,8 @@ function formatTimeRange(range) {
   if (!range || !range.open || !range.close) return 'geschlossen'
   return `${range.open} – ${range.close}`
 }
+
+const lockTypeLabels = computed(() =>
+  (company.value.lock_types || []).map((t) => LOCK_TYPE_LABELS[t] || t)
+)
 </script>

--- a/src/stores/company.js
+++ b/src/stores/company.js
@@ -50,8 +50,11 @@ export const filteredCompanies = computed(() => {
     const inPrice = price >= filters.price[0] && price <= filters.price[1]
 
     const matchesOpen = !filters.openNow || isOpen
+    const matchesLock =
+      filters.lockTypes.length === 0 ||
+      (company.lock_types || []).some((t) => filters.lockTypes.includes(t))
 
-    return matchesPLZ && matchesOpen && inPrice
+    return matchesPLZ && matchesOpen && inPrice && matchesLock
   })
 })
 

--- a/src/stores/filters.js
+++ b/src/stores/filters.js
@@ -3,7 +3,8 @@ import { reactive } from 'vue'
 export const filters = reactive({
   openNow: false,
   price: [0, 1000],
-  location: ''
+  location: '',
+  lockTypes: []
 })
 
 export function toggleFilter(key) {
@@ -15,6 +16,8 @@ export function clearFilter(key) {
     filters.price = [0, 1000]
   } else if (key === 'location') {
     filters.location = ''
+  } else if (key === 'lockTypes') {
+    filters.lockTypes = []
   } else {
     filters[key] = false
   }


### PR DESCRIPTION
## Summary
- define lock type categories and labels
- support selecting lock types in filters and provider forms
- filter and display providers by supported lock types

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c9248d6808321ad153f631e665bd2