### PR TITLE
Expand filter bar and display lock type icons

### DIFF
--- a/src/components/user/FilterBar.vue
+++ b/src/components/user/FilterBar.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="root" class="sticky top-2 z-30 flex justify-center px-2" @click.self="activeField = null">
     <div
-      class="flex w-full max-w-4xl items-center divide-x overflow-hidden rounded-full border border-gray-100 bg-white/80 px-4 py-3 text-base shadow-lg backdrop-blur transition-all duration-200 sm:py-2 sm:text-sm"
+      class="flex w-full max-w-5xl items-center divide-x overflow-hidden rounded-full border border-gray-100 bg-white/80 px-4 py-3 text-base shadow-lg backdrop-blur transition-all duration-200 sm:py-2 sm:text-sm"
       :class="{ 'scale-105 py-3': expanded }"
     >
       <div

--- a/src/components/user/SearchResultTile.vue
+++ b/src/components/user/SearchResultTile.vue
@@ -28,8 +28,18 @@
           {{ openStatus }}
         </span>
       </p>
-      <p v-if="lockTypeLabels.length" class="text-xs text-gray-500">
-        Kompatibel mit: {{ lockTypeLabels.join(', ') }}
+      <p
+        v-if="lockTypeIcons.length"
+        class="text-xs text-gray-500 flex items-center gap-1"
+      >
+        <span>Kompatibel mit:</span>
+        <span
+          v-for="(icon, idx) in lockTypeIcons"
+          :key="idx"
+          :title="lockTypeLabels[idx]"
+        >
+          {{ icon }}
+        </span>
       </p>
     </div>
   </li>
@@ -38,7 +48,7 @@
 <script setup>
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { LOCK_TYPE_LABELS } from '@/constants/lockTypes'
+import { LOCK_TYPE_LABELS, LOCK_TYPE_ICONS } from '@/constants/lockTypes'
 
 const props = defineProps({
   company: {
@@ -87,6 +97,10 @@ const borderColor = computed(() =>
 
 const lockTypeLabels = computed(() =>
   (props.company.lock_types || []).map((t) => LOCK_TYPE_LABELS[t] || t)
+)
+
+const lockTypeIcons = computed(() =>
+  (props.company.lock_types || []).map((t) => LOCK_TYPE_ICONS[t] || '')
 )
 
 function navigateToDetails() {

--- a/src/constants/lockTypes.js
+++ b/src/constants/lockTypes.js
@@ -1,13 +1,18 @@
 export const LOCK_TYPE_OPTIONS = [
-  { value: 'house', label: 'Haustür / Wohnungstür' },
-  { value: 'car_mechanical', label: 'Auto (mechanisch)' },
-  { value: 'car_electronic', label: 'Auto (elektronisch / Wegfahrsperre)' },
-  { value: 'bike', label: 'Fahrradschloss' },
-  { value: 'padlock', label: 'Vorhängeschloss' },
-  { value: 'safe', label: 'Tresor' },
-  { value: 'smart', label: 'Bluetooth-/Smartlock' },
-  { value: 'mailbox', label: 'Briefkasten' },
-  { value: 'other', label: 'Sonstiges' }
+  { value: 'house', label: 'Haustür / Wohnungstür', icon: '🏠' },
+  { value: 'car_mechanical', label: 'Auto (mechanisch)', icon: '🚗' },
+  { value: 'car_electronic', label: 'Auto (elektronisch / Wegfahrsperre)', icon: '🚘' },
+  { value: 'bike', label: 'Fahrradschloss', icon: '🚲' },
+  { value: 'padlock', label: 'Vorhängeschloss', icon: '🔒' },
+  { value: 'safe', label: 'Tresor', icon: '📦' },
+  { value: 'smart', label: 'Bluetooth-/Smartlock', icon: '📱' },
+  { value: 'mailbox', label: 'Briefkasten', icon: '📮' },
+  { value: 'other', label: 'Sonstiges', icon: '❓' }
 ]
 
-export const LOCK_TYPE_LABELS = Object.fromEntries(LOCK_TYPE_OPTIONS.map(o => [o.value, o.label]))
+export const LOCK_TYPE_LABELS = Object.fromEntries(
+  LOCK_TYPE_OPTIONS.map(o => [o.value, o.label])
+)
+export const LOCK_TYPE_ICONS = Object.fromEntries(
+  LOCK_TYPE_OPTIONS.map(o => [o.value, o.icon])
+)

--- a/src/pages/user/CompanyDetailView.vue
+++ b/src/pages/user/CompanyDetailView.vue
@@ -45,15 +45,16 @@
           <p class="text-gray-700">{{ company.description || 'Keine Beschreibung' }}</p>
         </div>
 
-        <div v-if="lockTypeLabels.length" class="mt-6">
+        <div v-if="lockTypeIcons.length" class="mt-6">
           <h2 class="font-semibold mb-2 text-black">Kompatible Schlösser</h2>
           <div class="flex flex-wrap gap-2">
             <span
-              v-for="t in lockTypeLabels"
-              :key="t"
-              class="bg-gray-100 text-gray-800 text-xs px-2 py-1 rounded-full"
+              v-for="(icon, idx) in lockTypeIcons"
+              :key="idx"
+              class="bg-gray-100 text-gray-800 text-xl px-2 py-1 rounded-full"
+              :title="lockTypeLabels[idx]"
             >
-              {{ t }}
+              {{ icon }}
             </span>
           </div>
         </div>
@@ -89,7 +90,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { getCompany } from '@/services/company'
 import DataRow from '@/components/common/DataRow.vue'
-import { LOCK_TYPE_LABELS } from '@/constants/lockTypes'
+import { LOCK_TYPE_LABELS, LOCK_TYPE_ICONS } from '@/constants/lockTypes'
 
 const route = useRoute()
 const companyId = route.params.id
@@ -166,5 +167,9 @@ function formatTimeRange(range) {
 
 const lockTypeLabels = computed(() =>
   (company.value.lock_types || []).map((t) => LOCK_TYPE_LABELS[t] || t)
+)
+
+const lockTypeIcons = computed(() =>
+  (company.value.lock_types || []).map((t) => LOCK_TYPE_ICONS[t] || '')
 )
 </script>


### PR DESCRIPTION
## Summary
- Widen desktop filter bar for better spacing when selecting locks
- Add emoji-based icons for lock types and show them on search results and company profiles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c95b429a4832181be4ab7ba9ded83