### PR TITLE
Fix overlapping content with filter bar

### DIFF
--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -2,7 +2,7 @@
   <!-- Allgemeines Seitenlayout mit Header und optionalem Footer -->
   <div class="flex flex-col min-h-screen text-black">
     <Header />
-    <main class="flex-1 flex justify-center items-start pt-20">
+    <main class="flex-1 flex justify-center items-start pt-24">
       <div class="w-full max-w-4xl px-6 py-8">
         <!-- Hier werden die Seiteninhalte eingeblendet -->
         <router-view />


### PR DESCRIPTION
## Summary
- increase default layout top padding so page content sits below the filter bar

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c995d798c8321865e3cd8a04f2196