### PR TITLE
Add multi-step onboarding wizard for providers

### DIFF
--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -36,7 +36,7 @@
       </router-link>
 
       <template v-if="!companyData">
-        <router-link to="/register" class="btn-outline hidden md:inline-flex items-center" v-show="!hideNavOnHomeMobile">
+        <router-link to="/onboarding" class="btn-outline hidden md:inline-flex items-center" v-show="!hideNavOnHomeMobile">
           <i class="fa fa-key mr-2 animate-bounce"></i>
           Werde Problemsolver:in
         </router-link>

--- a/src/pages/company/OnboardingView.vue
+++ b/src/pages/company/OnboardingView.vue
@@ -1,0 +1,285 @@
+<template>
+  <div class="max-w-xl mx-auto mt-10 p-8 bg-white rounded-xl shadow">
+    <h1 class="text-3xl font-semibold mb-8 text-center text-black">
+      <p class="text-center text-gold font-medium mb-4">
+        <i class="fa fa-key mr-2 animate-bounce"></i> Werde Problemsolver:in
+      </p>
+      Unternehmens-Onboarding
+    </h1>
+
+    <!-- Schritt 1: Firmendaten -->
+    <div v-if="step === 1">
+      <FormKit
+        type="form"
+        :actions="false"
+        @submit="handleStep1"
+        :config="{ validationVisibility: 'blur' }"
+        class="space-y-6"
+      >
+        <FormKit
+          type="text"
+          name="company_name"
+          label="Firmenname"
+          validation="required"
+          placeholder="z. B. Schlüsseldienst Müller"
+          :classes="{ label: 'label', input: 'input' }"
+        />
+
+        <FormKit
+          type="email"
+          name="email"
+          label="E-Mail"
+          validation="required|email"
+          placeholder="beispiel@firma.de"
+          :classes="{ label: 'label', input: 'input' }"
+        />
+
+        <FormKit
+          type="password"
+          name="password"
+          label="Passwort"
+          validation="required|min:6"
+          placeholder="Mind. 6 Zeichen"
+          :classes="{ label: 'label', input: 'input' }"
+        />
+
+        <FormKit
+          type="password"
+          name="confirm_password"
+          label="Passwort wiederholen"
+          validation="required|confirm:password"
+          placeholder="Nochmals eingeben"
+          :classes="{ label: 'label', input: 'input' }"
+        />
+
+        <FormKit
+          type="tel"
+          name="phone"
+          label="Telefonnummer"
+          validation="required"
+          placeholder="z. B. 0151 12345678"
+          :classes="{ label: 'label', input: 'input' }"
+        />
+
+        <FormKit
+          type="text"
+          name="address"
+          label="Straße und Hausnummer"
+          :classes="{ label: 'label', input: 'input' }"
+        />
+
+        <FormKit
+          type="text"
+          name="city"
+          label="Ort"
+          :classes="{ label: 'label', input: 'input' }"
+        />
+
+        <FormKit
+          type="text"
+          name="postal_code"
+          label="Postleitzahl"
+          :classes="{ label: 'label', input: 'input' }"
+        />
+
+        <div class="flex justify-end">
+          <Button>Weiter</Button>
+        </div>
+      </FormKit>
+    </div>
+
+    <!-- Schritt 2: Öffnungszeiten -->
+    <div v-else-if="step === 2" class="space-y-6">
+      <OpeningHoursForm v-model="form.opening_hours" />
+      <div class="flex justify-between mt-6">
+        <Button type="button" class="btn-outline" @click="step--">Zurück</Button>
+        <Button type="button" @click="step++">Weiter</Button>
+      </div>
+    </div>
+
+    <!-- Schritt 3: Schlosstypen / Services -->
+    <div v-else-if="step === 3">
+      <FormKit
+        type="form"
+        :actions="false"
+        @submit="handleStep3"
+        class="space-y-6"
+      >
+        <div>
+          <label class="label">Schlosstypen</label>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <label
+              v-for="opt in lockTypeOptions"
+              :key="opt.value"
+              class="flex items-center gap-2 text-sm"
+            >
+              <input
+                type="checkbox"
+                :value="opt.value"
+                v-model="form.lock_types"
+                class="accent-gold"
+              />
+              <span>{{ opt.label }}</span>
+            </label>
+          </div>
+        </div>
+
+        <FormKit
+          type="number"
+          name="price"
+          label="Preis (ab)"
+          min="0"
+          :classes="{ label: 'label', input: 'input' }"
+        />
+
+        <FormKit
+          type="textarea"
+          name="description"
+          label="Beschreibung"
+          :classes="{ label: 'label', input: 'textarea' }"
+        />
+
+        <FormKit
+          type="checkbox"
+          name="is_247"
+          label="24/7 Notdienst"
+          v-model="form.is_247"
+          :classes="{ label: 'label' }"
+        />
+
+        <FormKit
+          v-if="form.is_247"
+          type="number"
+          name="emergency_price"
+          label="Notdienstpreis"
+          validation="required"
+          min="0"
+          :classes="{ label: 'label', input: 'input' }"
+        />
+
+        <div class="flex justify-between">
+          <Button type="button" class="btn-outline" @click="step--">Zurück</Button>
+          <Button>Weiter</Button>
+        </div>
+      </FormKit>
+    </div>
+
+    <!-- Schritt 4: Vorschau & Bestätigung -->
+    <div v-else-if="step === 4" class="space-y-4">
+      <h2 class="text-xl font-semibold mb-4">Vorschau</h2>
+      <div class="text-sm space-y-1">
+        <p><strong>Firma:</strong> {{ form.company_name }}</p>
+        <p><strong>E-Mail:</strong> {{ form.email }}</p>
+        <p><strong>Telefon:</strong> {{ form.phone }}</p>
+        <p><strong>Adresse:</strong> {{ form.address }}, {{ form.postal_code }} {{ form.city }}</p>
+        <p><strong>Preis:</strong> {{ form.price }}</p>
+        <p><strong>Beschreibung:</strong> {{ form.description }}</p>
+        <p>
+          <strong>24/7:</strong>
+          {{ form.is_247 ? 'Ja (Preis: ' + form.emergency_price + ')' : 'Nein' }}
+        </p>
+        <p>
+          <strong>Schlosstypen:</strong>
+          {{ form.lock_types.join(', ') || '-' }}
+        </p>
+      </div>
+      <div class="flex justify-between mt-6">
+        <Button type="button" class="btn-outline" @click="step--">Zurück</Button>
+        <Button type="button" @click="register">Bestätigen</Button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { auth, db } from '@/firebase'
+import { createUserWithEmailAndPassword } from 'firebase/auth'
+import { doc, setDoc } from 'firebase/firestore'
+import Button from '@/components/common/Button.vue'
+import OpeningHoursForm from '@/components/company/OpeningHoursForm.vue'
+import { LOCK_TYPE_OPTIONS } from '@/constants/lockTypes'
+
+const router = useRouter()
+const step = ref(1)
+
+const form = ref({
+  company_name: '',
+  email: '',
+  password: '',
+  confirm_password: '',
+  phone: '',
+  address: '',
+  city: '',
+  postal_code: '',
+  opening_hours: {},
+  lock_types: [],
+  price: '',
+  description: '',
+  is_247: false,
+  emergency_price: ''
+})
+
+const lockTypeOptions = LOCK_TYPE_OPTIONS
+
+function handleStep1(data) {
+  Object.assign(form.value, data)
+  step.value = 2
+}
+
+function handleStep3(data) {
+  form.value.price = data.price
+  form.value.description = data.description
+  form.value.emergency_price = data.emergency_price
+  step.value = 4
+}
+
+async function register() {
+  try {
+    const { user } = await createUserWithEmailAndPassword(
+      auth,
+      form.value.email,
+      form.value.password
+    )
+    await setDoc(doc(db, 'companies', user.uid), {
+      company_name: form.value.company_name,
+      email: form.value.email,
+      phone: form.value.phone,
+      address: form.value.address,
+      city: form.value.city,
+      postal_code: form.value.postal_code,
+      price: form.value.price,
+      description: form.value.description,
+      lock_types: form.value.lock_types,
+      opening_hours: form.value.opening_hours,
+      is_247: form.value.is_247,
+      emergency_price: form.value.is_247 ? form.value.emergency_price || '' : '',
+      created_at: new Date().toISOString(),
+      verified: false,
+    })
+    router.push({
+      name: 'success',
+      query: { msg: 'Registrierung erfolgreich', next: '/dashboard' }
+    })
+  } catch (e) {
+    alert('Fehler bei der Registrierung: ' + e.message)
+  }
+}
+</script>
+
+<style scoped>
+.label {
+  @apply block text-sm font-medium mb-1;
+}
+.input {
+  @apply w-full border border-gray-300 rounded-xl px-3 py-2 focus:ring-2 focus:ring-gold focus:border-gold;
+}
+.textarea {
+  @apply w-full border border-gray-300 rounded-xl px-3 py-2 min-h-[100px] focus:ring-2 focus:ring-gold focus:border-gold;
+}
+:deep(.btn-outline) {
+  @apply rounded-full px-4 py-2 font-medium border border-gold text-gold bg-white hover:bg-gold/10 transition-colors;
+}
+</style>
+

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -19,6 +19,7 @@ const routes = [
       { path: '', name: 'home', component: HomeView },
       { path: 'login', name: 'login', component: () => import('@/pages/company/LoginView.vue') },
       { path: 'register', name: 'register', component: () => import('@/pages/company/RegisterView.vue') },
+      { path: 'onboarding', name: 'onboarding', component: () => import('@/pages/company/OnboardingView.vue') },
       { path: 'reset-password', name: 'reset-password', component: () => import('@/pages/ResetPasswordView.vue') },
       {
         path: 'dashboard',


### PR DESCRIPTION
## Summary
- add onboarding route and update header CTA to link to it
- implement four-step onboarding wizard for company registration

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c9cdfca648321b4d657d61c0f46bd