### PR TITLE
Fix content overlap beneath sticky filter bar

### DIFF
--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -1,8 +1,8 @@
 <template>
   <!-- Allgemeines Seitenlayout mit Header und optionalem Footer -->
   <div class="flex flex-col min-h-screen text-black">
-    <Header />
-    <main class="flex-1 flex justify-center items-start pt-24">
+    <Header @update-height="headerHeight = $event" />
+    <main class="flex-1 flex justify-center items-start" :style="{ paddingTop: headerHeight + 'px' }">
       <div class="w-full max-w-4xl px-6 py-8">
         <!-- Hier werden die Seiteninhalte eingeblendet -->
         <router-view />
@@ -13,9 +13,12 @@
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import Header from '@/layouts/Header.vue'
 import Footer from '@/layouts/Footer.vue'
 // Optionale Anzeige des Footers steuern
+
+const headerHeight = ref(0)
 
 defineProps({
   showFooter: {


### PR DESCRIPTION
## Summary
- offset main content dynamically based on header height
- watch header size with ResizeObserver and emit updates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ca13b9a6c8321b9c647fc2c7a70b8