### PR TITLE
Improve header and FilterBar responsiveness

### DIFF
--- a/src/components/user/FilterBar.vue
+++ b/src/components/user/FilterBar.vue
@@ -1,11 +1,11 @@
 <template>
-  <div ref="root" class="sticky top-2 z-30 flex justify-center px-2" @click.self="activeField = null">
+  <div ref="root" class="sticky top-2 z-30 flex justify-center px-2 min-w-0" @click.self="activeField = null">
     <div
-      class="flex w-full max-w-5xl items-center divide-x overflow-hidden rounded-full border border-gray-100 bg-white/80 px-4 py-3 text-base shadow-lg backdrop-blur transition-all duration-200 sm:py-2 sm:text-sm"
+      class="flex w-full max-w-5xl items-center divide-x overflow-hidden rounded-full border border-gray-100 bg-white/80 px-4 py-3 text-base shadow-lg backdrop-blur transition-all duration-200 sm:py-2 sm:text-sm min-w-0"
       :class="{ 'scale-105 py-3': expanded }"
     >
       <div
-        class="relative flex flex-1 items-center gap-2 py-3 px-4 transition-all duration-200 sm:py-2"
+        class="relative flex flex-1 min-w-0 items-center gap-2 py-3 px-4 transition-all duration-200 sm:py-2"
         :class="{ 'z-10 scale-105 bg-white': activeField === 'location' || filters.location }"
         @click.stop="activeField = 'location'"
       >
@@ -13,7 +13,7 @@
         <input
           v-model="filters.location"
           placeholder="Wo?"
-          class="flex-1 border-none bg-transparent text-base placeholder:text-gray-400 focus:ring-0 sm:text-sm"
+          class="flex-1 min-w-0 border-none bg-transparent text-base placeholder:text-gray-400 focus:ring-0 sm:text-sm"
           autocomplete="postal-code"
           @focus="activeField = 'location'"
         />
@@ -26,43 +26,43 @@
         </button>
       </div>
       <button
-        class="relative flex flex-shrink-0 items-center gap-2 py-3 px-4 text-base transition-all duration-200 hover:bg-gray-50 sm:py-2 sm:text-sm"
+        class="relative flex items-center gap-2 py-3 px-4 text-base transition-all duration-200 hover:bg-gray-50 sm:py-2 sm:text-sm"
         :class="{ 'z-10 scale-105 bg-white text-gold': activeField === 'openNow' || filters.openNow }"
         @click.stop="toggleFilter('openNow'); activeField = 'openNow'"
       >
         <Clock class="h-5 w-5" />
-        <span class="hidden sm:inline">Jetzt geöffnet</span>
+        <span class="hidden lg:inline">Jetzt geöffnet</span>
         <span v-if="filters.openNow" @click.stop="clearFilter('openNow')" class="ml-1 cursor-pointer text-gray-400 hover:text-black">
           <X class="h-3 w-3" />
         </span>
       </button>
       <button
-        class="relative flex flex-shrink-0 items-center gap-2 py-3 px-4 text-base transition-all duration-200 hover:bg-gray-50 sm:py-2 sm:text-sm"
+        class="relative flex items-center gap-2 py-3 px-4 text-base transition-all duration-200 hover:bg-gray-50 sm:py-2 sm:text-sm"
         :class="{ 'z-10 scale-105 bg-white text-gold': activeField === 'price' || priceActive }"
         @click.stop="openPrice"
       >
         <Euro class="h-5 w-5" />
-        <span class="hidden sm:inline" v-if="!priceActive">Preis</span>
-        <span class="hidden sm:inline" v-else>{{ filters.price[0] }}€ - {{ filters.price[1] }}€</span>
+        <span class="hidden lg:inline" v-if="!priceActive">Preis</span>
+        <span class="hidden lg:inline" v-else>{{ filters.price[0] }}€ - {{ filters.price[1] }}€</span>
         <span v-if="priceActive" @click.stop="clearFilter('price')" class="ml-1 cursor-pointer text-gray-400 hover:text-black">
           <X class="h-3 w-3" />
         </span>
         <ChevronDown v-else class="h-4 w-4" />
       </button>
       <button
-        class="relative flex flex-shrink-0 items-center gap-2 py-3 px-4 text-base transition-all duration-200 hover:bg-gray-50 sm:py-2 sm:text-sm"
+        class="relative flex items-center gap-2 py-3 px-4 text-base transition-all duration-200 hover:bg-gray-50 sm:py-2 sm:text-sm"
         :class="{ 'z-10 scale-105 bg-white text-gold': activeField === 'lockTypes' || filters.lockTypes.length }"
         @click.stop="openLockTypes"
       >
         <Lock class="h-5 w-5" />
-        <span class="hidden sm:inline" v-if="!filters.lockTypes.length">Schlösser</span>
-        <span class="hidden sm:inline" v-else>{{ filters.lockTypes.length }} ausgewählt</span>
+        <span class="hidden lg:inline" v-if="!filters.lockTypes.length">Schlösser</span>
+        <span class="hidden lg:inline" v-else>{{ filters.lockTypes.length }} ausgewählt</span>
         <span v-if="filters.lockTypes.length" @click.stop="clearFilter('lockTypes')" class="ml-1 cursor-pointer text-gray-400 hover:text-black">
           <X class="h-3 w-3" />
         </span>
         <ChevronDown v-else class="h-4 w-4" />
       </button>
-      <div class="flex justify-end py-3 pl-4 pr-4 sm:py-0">
+      <div class="flex flex-shrink-0 justify-end py-3 pl-4 pr-4 sm:py-0">
         <button class="rounded-full bg-gold p-2 text-white hover:bg-gold/90" aria-label="Suchen">
           <Search class="h-4 w-4" />
         </button>

--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -10,18 +10,18 @@
       class="flex items-center gap-1 sm:gap-2 px-2 sm:px-3 py-1 sm:py-2 rounded-lg border border-transparent hover:border-gold/50 hover:bg-gold/5 transition-colors"
       v-show="!hideNavOnHomeMobile"
     >
-      <img src="/logo.png" alt="Logo" class="h-10 sm:h-12 w-auto" />
-      <span class="font-bold text-lg sm:text-xl text-gold">Magikey</span>
+      <img src="/logo.png" alt="Logo" class="h-8 sm:h-10 md:h-12 w-auto" />
+      <span class="font-bold text-base sm:text-lg md:text-xl text-gold">Magikey</span>
     </router-link>
 
     <nav class="hidden md:flex items-center gap-4 lg:gap-6 text-sm font-medium"></nav>
 
-    <div class="flex-1 flex justify-center px-2 sm:px-4" v-if="showFilterBar">
+    <div class="flex-1 min-w-0 flex justify-center px-2 sm:px-4" v-if="showFilterBar">
       <MobileFilterBar v-if="isMobile" />
       <transition name="slide-down">
         <FilterBar
           v-show="!isMobile"
-          class="w-full max-w-2xl"
+          class="w-full max-w-2xl min-w-0"
           :expanded="searchActive"
           @focus="searchActive = true"
           @blur="searchActive = false"
@@ -29,11 +29,11 @@
       </transition>
     </div>
 
-    <div class="flex items-center gap-2 sm:gap-3">
+    <div class="flex items-center gap-1 sm:gap-2 md:gap-3">
       <!-- Link zum Dashboard wenn Firma eingeloggt ist -->
       <router-link v-if="companyData" to="/dashboard" class="flex items-center gap-1 sm:gap-2 hover:underline" v-show="!hideNavOnHomeMobile">
-        <img :src="companyData.logo_url || '/logo.png'" alt="Logo" class="w-8 h-8 sm:w-9 sm:h-9 rounded-full object-cover" />
-        <span class="font-medium text-sm sm:text-base">{{ companyData.company_name }}</span>
+        <img :src="companyData.logo_url || '/logo.png'" alt="Logo" class="w-7 h-7 sm:w-8 sm:h-8 md:w-9 md:h-9 rounded-full object-cover" />
+        <span class="font-medium text-xs sm:text-sm md:text-base">{{ companyData.company_name }}</span>
       </router-link>
 
       <template v-if="!companyData">
@@ -46,7 +46,7 @@
       <!-- Button zum Öffnen des mobilen Overlays -->
       <button
         @click="toggleOverlay"
-        class="text-lg sm:text-xl hover:text-gold transition-colors focus:outline-none"
+        class="text-base sm:text-lg md:text-xl hover:text-gold transition-colors focus:outline-none"
         :class="{ 'rotate-90': showOverlay }"
         aria-label="Menü"
         ref="menuButton"


### PR DESCRIPTION
## Summary
- Make logo, filter bar, and user actions in `Header.vue` responsive to small screens
- Allow `FilterBar` to shrink by hiding labels on narrow viewports and adding min-width handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca83a87ec8321a99e7859eb76adf1