### PR TITLE
Display lock names alongside icons

### DIFF
--- a/src/components/user/SearchResultTile.vue
+++ b/src/components/user/SearchResultTile.vue
@@ -29,17 +29,11 @@
         </span>
       </p>
       <p
-        v-if="lockTypeIcons.length"
+        v-if="lockTypes.length"
         class="text-xs text-gray-500 flex items-center gap-1"
       >
         <span>Kompatibel mit:</span>
-        <span
-          v-for="(icon, idx) in lockTypeIcons"
-          :key="idx"
-          :title="lockTypeLabels[idx]"
-        >
-          {{ icon }}
-        </span>
+        <span>{{ lockTypeDisplay }}</span>
       </p>
     </div>
   </li>
@@ -95,12 +89,15 @@ const borderColor = computed(() =>
   isOpen.value ? 'border-green-500' : props.company.is_247 ? 'border-red-500' : 'border-gray-300'
 )
 
-const lockTypeLabels = computed(() =>
-  (props.company.lock_types || []).map((t) => LOCK_TYPE_LABELS[t] || t)
+const lockTypes = computed(() =>
+  (props.company.lock_types || []).map((t) => ({
+    icon: LOCK_TYPE_ICONS[t] || '',
+    label: LOCK_TYPE_LABELS[t] || t
+  }))
 )
 
-const lockTypeIcons = computed(() =>
-  (props.company.lock_types || []).map((t) => LOCK_TYPE_ICONS[t] || '')
+const lockTypeDisplay = computed(() =>
+  lockTypes.value.map((lt) => `${lt.icon} ${lt.label}`).join(', ')
 )
 
 function navigateToDetails() {

--- a/src/pages/user/CompanyDetailView.vue
+++ b/src/pages/user/CompanyDetailView.vue
@@ -45,16 +45,16 @@
           <p class="text-gray-700">{{ company.description || 'Keine Beschreibung' }}</p>
         </div>
 
-        <div v-if="lockTypeIcons.length" class="mt-6">
+        <div v-if="lockTypes.length" class="mt-6">
           <h2 class="font-semibold mb-2 text-black">Kompatible Schlösser</h2>
           <div class="flex flex-wrap gap-2">
             <span
-              v-for="(icon, idx) in lockTypeIcons"
+              v-for="(lt, idx) in lockTypes"
               :key="idx"
-              class="bg-gray-100 text-gray-800 text-xl px-2 py-1 rounded-full"
-              :title="lockTypeLabels[idx]"
+              class="bg-gray-100 text-gray-800 text-sm px-2 py-1 rounded-full flex items-center gap-1"
             >
-              {{ icon }}
+              <span class="text-xl">{{ lt.icon }}</span>
+              <span>{{ lt.label }}</span>
             </span>
           </div>
         </div>
@@ -165,11 +165,10 @@ function formatTimeRange(range) {
   return `${range.open} – ${range.close}`
 }
 
-const lockTypeLabels = computed(() =>
-  (company.value.lock_types || []).map((t) => LOCK_TYPE_LABELS[t] || t)
-)
-
-const lockTypeIcons = computed(() =>
-  (company.value.lock_types || []).map((t) => LOCK_TYPE_ICONS[t] || '')
+const lockTypes = computed(() =>
+  (company.value.lock_types || []).map((t) => ({
+    icon: LOCK_TYPE_ICONS[t] || '',
+    label: LOCK_TYPE_LABELS[t] || t
+  }))
 )
 </script>


### PR DESCRIPTION
## Summary
- show lock type name beside emoji on company detail page
- include lock names next to icons in search results

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d9ceab30883218b64df14ca0078cd