### PR TITLE
Show only lock type emojis on home page

### DIFF
--- a/src/components/user/SearchResultTile.vue
+++ b/src/components/user/SearchResultTile.vue
@@ -32,7 +32,6 @@
         v-if="lockTypes.length"
         class="text-xs text-gray-500 flex items-center gap-1"
       >
-        <span>Kompatibel mit:</span>
         <span>{{ lockTypeDisplay }}</span>
       </p>
     </div>
@@ -97,7 +96,7 @@ const lockTypes = computed(() =>
 )
 
 const lockTypeDisplay = computed(() =>
-  lockTypes.value.map((lt) => `${lt.icon} ${lt.label}`).join(', ')
+  lockTypes.value.map((lt) => lt.icon).join(' ')
 )
 
 function navigateToDetails() {


### PR DESCRIPTION
## Summary
- Simplify provider list entries by displaying only lock type emojis instead of full labels

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d9ea682d08321ade95b63b4f64394