### PR TITLE
Add hero section under search filter

### DIFF
--- a/src/components/user/HeroSection.vue
+++ b/src/components/user/HeroSection.vue
@@ -1,0 +1,30 @@
+<template>
+  <!-- Intro-Panel unterhalb der Filterleiste -->
+  <section
+    class="relative overflow-hidden rounded-lg border border-gray-200 bg-gray-50 p-4 sm:p-6 mt-2 mb-6"
+  >
+    <h1 class="mb-3 flex items-center gap-2 text-lg font-semibold sm:text-xl">
+      <span class="text-gold">
+        <i class="fa fa-key"></i>
+      </span>
+      Schnell den passenden Schlüsseldienst finden
+    </h1>
+    <ul class="space-y-1 text-sm sm:text-base">
+      <li class="flex items-start gap-2">
+        <span>✅</span>
+        <span>Vergleiche Preis, Öffnungszeiten und Bewertungen</span>
+      </li>
+      <li class="flex items-start gap-2">
+        <span>📍</span>
+        <span>Für alle Schlosstypen: Haus, Auto, Fahrrad & mehr</span>
+      </li>
+    </ul>
+    <i
+      class="fa fa-unlock-alt pointer-events-none absolute bottom-4 right-4 hidden text-6xl text-gray-300 opacity-20 md:block"
+    ></i>
+  </section>
+</template>
+
+<script setup>
+// Dieses Panel ist rein informativ und benötigt keine Logik
+</script>

--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -1,7 +1,7 @@
 <template>
-  <!-- Startseite mit Filterleiste und Firmenliste -->
+  <!-- Startseite mit Filterleiste, Hero-Panel und Firmenliste -->
   <div class="mx-auto max-w-4xl min-h-screen bg-white px-4 py-6 sm:px-6">
-    <h1 class="mb-4 text-center text-2xl font-semibold">Schlüsseldienste in deiner Nähe</h1>
+    <HeroSection />
 
     <div>
       <div v-if="loading" class="flex flex-col items-center py-10 text-gray-500">
@@ -23,6 +23,7 @@
 import { onMounted, defineAsyncComponent } from 'vue'
 import SearchResults from '@/components/user/SearchResults.vue'
 import Loader from '@/components/common/Loader.vue'
+import HeroSection from '@/components/user/HeroSection.vue'
 import { getPostalFromCoords } from '@/firebase/functions'
 import { filters } from '@/stores/filters'
 import { useCompanyStore } from '@/stores/company'


### PR DESCRIPTION
## Summary
- add HeroSection component introducing Magikey features
- render hero panel on home page under filter bar

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d9ef2abb48321868c50de07f2369c