### PR TITLE
feat: animate search results on filter change

### DIFF
--- a/src/components/user/SearchResults.vue
+++ b/src/components/user/SearchResults.vue
@@ -4,13 +4,18 @@
       Keine Ergebnisse gefunden
     </p>
 
-    <ul v-else class="grid grid-cols-1 gap-4 auto-rows-fr">
+    <TransitionGroup
+      v-else
+      name="slide"
+      tag="ul"
+      class="grid grid-cols-1 gap-4 auto-rows-fr"
+    >
       <SearchResultTile
         v-for="company in companies"
         :key="company.id"
         :company="company"
       />
-    </ul>
+    </TransitionGroup>
   </div>
 </template>
 
@@ -24,3 +29,16 @@ defineProps({
   }
 })
 </script>
+
+<style scoped>
+.slide-enter-active,
+.slide-leave-active {
+  transition: all 0.3s ease;
+}
+
+.slide-enter-from,
+.slide-leave-to {
+  opacity: 0;
+  transform: translateY(10px);
+}
+</style>


### PR DESCRIPTION
## Summary
- animate search result cards with slide-in effect on filter change

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d9f2d80548321af8b948b54eb32d3