### PR TITLE
Add dynamic heading and sticky footer

### DIFF
--- a/src/components/user/IntroPopup.vue
+++ b/src/components/user/IntroPopup.vue
@@ -1,8 +1,5 @@
 <template>
-  <!-- Intro-Panel unterhalb der Filterleiste -->
-  <section
-    class="relative overflow-hidden rounded-lg border border-gray-200 bg-gray-50 p-4 sm:p-6 mt-2 mb-6"
-  >
+  <section class="relative overflow-hidden rounded-lg border border-gray-200 bg-gray-50 p-4 sm:p-6">
     <h1 class="mb-3 flex items-center gap-2 text-lg font-semibold sm:text-xl">
       <span class="text-gold">
         <i class="fa fa-key"></i>
@@ -28,3 +25,4 @@
 <script setup>
 // Dieses Panel ist rein informativ und benötigt keine Logik
 </script>
+

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -5,7 +5,7 @@
       Seite im Aufbau – Impressum folgt
     </div>
     <Header @update-height="headerHeight = $event" />
-    <main class="flex-1 flex justify-center items-start" :style="{ paddingTop: headerHeight + 'px' }">
+    <main class="flex-1 flex justify-center items-start pb-24" :style="{ paddingTop: headerHeight + 'px' }">
       <div class="w-full max-w-4xl px-6 py-8">
         <!-- Hier werden die Seiteninhalte eingeblendet -->
         <router-view />

--- a/src/layouts/Footer.vue
+++ b/src/layouts/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="bg-black text-white py-4 px-6 text-sm text-center mt-auto">
+  <footer class="fixed bottom-0 left-0 w-full bg-black text-white py-4 px-6 text-sm text-center z-50">
     <div class="flex justify-center items-center gap-4 text-white/70">
       <router-link to="/impressum" class="hover:underline">Impressum</router-link>
       <span class="opacity-40">|</span>

--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -1,7 +1,7 @@
 <template>
-  <!-- Startseite mit Filterleiste, Hero-Panel und Firmenliste -->
+  <!-- Startseite mit Filterleiste und Firmenliste -->
   <div class="mx-auto max-w-4xl min-h-screen bg-white px-4 py-6 sm:px-6">
-    <HeroSection />
+    <h1 class="mb-6 text-2xl font-semibold">{{ title }}</h1>
 
     <div>
       <div v-if="loading" class="flex flex-col items-center py-10 text-gray-500">
@@ -17,20 +17,46 @@
       </template>
     </div>
   </div>
+  <transition name="modal">
+    <div
+      v-if="showIntro"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      @click.self="showIntro = false"
+    >
+      <div class="w-full max-w-md">
+        <IntroPopup />
+        <button
+          class="mt-4 w-full rounded bg-black py-2 text-white"
+          @click="showIntro = false"
+        >
+          Schließen
+        </button>
+      </div>
+    </div>
+  </transition>
 </template>
 
 <script setup>
-import { onMounted, defineAsyncComponent } from 'vue'
+import { onMounted, defineAsyncComponent, ref, computed } from 'vue'
 import SearchResults from '@/components/user/SearchResults.vue'
 import Loader from '@/components/common/Loader.vue'
-import HeroSection from '@/components/user/HeroSection.vue'
+import IntroPopup from '@/components/user/IntroPopup.vue'
 import { getPostalFromCoords } from '@/firebase/functions'
 import { filters } from '@/stores/filters'
 import { useCompanyStore } from '@/stores/company'
+import { auth } from '@/firebase'
+import { onAuthStateChanged } from 'firebase/auth'
 
 const NotifyForm = defineAsyncComponent(() => import('@/components/user/NotifyForm.vue'))
 
 const { loading, fetchCompanies, filteredCompanies } = useCompanyStore()
+const showIntro = ref(false)
+const title = computed(() => {
+  let text = 'Schlüsseldienste'
+  if (filters.location) text += ` in ${filters.location}`
+  if (filters.price[1] < 1000) text += ` bis ${filters.price[1]}€`
+  return text
+})
 
 // Versucht, die Postleitzahl über Geolocation zu ermitteln
 async function useLocation() {
@@ -47,6 +73,9 @@ async function useLocation() {
 
 // Daten initial laden
 onMounted(async () => {
+  onAuthStateChanged(auth, (user) => {
+    if (!user) showIntro.value = true
+  })
   useLocation()
   await fetchCompanies()
 })


### PR DESCRIPTION
## Summary
- keep footer visible by fixing it to bottom of screen
- replace home hero with filter-based heading and intro popup for guests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689da0f2c2e083218ec948858ad9f9f0