### PR TITLE
refactor: centralize day constants

### DIFF
--- a/src/components/company/OpeningHoursForm.vue
+++ b/src/components/company/OpeningHoursForm.vue
@@ -28,23 +28,20 @@
 
 <script setup>
 import { ref, watch } from 'vue'
+import { DAYS, DAY_LABELS } from '@/constants/days'
 
 const props = defineProps({
   modelValue: { type: Object, default: () => ({}) }
 })
 const emit = defineEmits(['update:modelValue'])
 
-const days = [
-  { key: 'monday', short: 'Mo' },
-  { key: 'tuesday', short: 'Di' },
-  { key: 'wednesday', short: 'Mi' },
-  { key: 'thursday', short: 'Do' },
-  { key: 'friday', short: 'Fr' },
-  { key: 'saturday', short: 'Sa' },
-  { key: 'sunday', short: 'So' }
-]
+const days = DAYS.map(key => ({ key, short: DAY_LABELS[key] }))
 
-const selectedDays = ref(Object.keys(props.modelValue).length ? Object.keys(props.modelValue) : ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'])
+const selectedDays = ref(
+  Object.keys(props.modelValue).length
+    ? Object.keys(props.modelValue)
+    : DAYS.slice(0, 5)
+)
 const open = ref('')
 const close = ref('')
 

--- a/src/components/user/SearchResultTile.vue
+++ b/src/components/user/SearchResultTile.vue
@@ -42,6 +42,7 @@
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { LOCK_TYPE_LABELS, LOCK_TYPE_ICONS } from '@/constants/lockTypes'
+import { DAYS } from '@/constants/days'
 
 const props = defineProps({
   company: {
@@ -55,8 +56,7 @@ const router = useRouter()
 const isOpen = computed(() => {
   const now = new Date()
   const dayIndex = now.getDay() - 1
-  const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
-  const today = days[dayIndex < 0 ? 6 : dayIndex]
+  const today = DAYS[dayIndex < 0 ? 6 : dayIndex]
   const hours = props.company?.opening_hours?.[today]
 
   if (!hours || !hours.open || !hours.close) return false

--- a/src/constants/days.js
+++ b/src/constants/days.js
@@ -1,0 +1,11 @@
+export const DAYS = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
+
+export const DAY_LABELS = {
+  monday: 'Mo',
+  tuesday: 'Di',
+  wednesday: 'Mi',
+  thursday: 'Do',
+  friday: 'Fr',
+  saturday: 'Sa',
+  sunday: 'So'
+}

--- a/src/pages/company/DashboardView.vue
+++ b/src/pages/company/DashboardView.vue
@@ -81,6 +81,7 @@ import DataRow from '@/components/common/DataRow.vue'
 import Loader from '@/components/common/Loader.vue'
 import Button from '@/components/common/Button.vue'
 import { sendVerificationEmail } from '@/services/auth'
+import { DAYS, DAY_LABELS } from '@/constants/days'
 
 const company = ref(null)
 const loading = ref(true)
@@ -103,15 +104,7 @@ onMounted(async () => {
   }
 })
 
-const days = [
-  { key: 'monday', label: 'Mo' },
-  { key: 'tuesday', label: 'Di' },
-  { key: 'wednesday', label: 'Mi' },
-  { key: 'thursday', label: 'Do' },
-  { key: 'friday', label: 'Fr' },
-  { key: 'saturday', label: 'Sa' },
-  { key: 'sunday', label: 'So' },
-]
+const days = DAYS.map(key => ({ key, label: DAY_LABELS[key] }))
 
 function formatTimeRange(range) {
   if (!range || !range.open || !range.close) return 'geschlossen'

--- a/src/pages/user/CompanyDetailView.vue
+++ b/src/pages/user/CompanyDetailView.vue
@@ -91,11 +91,12 @@ import { useRoute } from 'vue-router'
 import { getCompany } from '@/services/company'
 import DataRow from '@/components/common/DataRow.vue'
 import { LOCK_TYPE_LABELS, LOCK_TYPE_ICONS } from '@/constants/lockTypes'
+import { DAYS, DAY_LABELS } from '@/constants/days'
 
 const route = useRoute()
 const companyId = route.params.id
 const company = ref({})
-const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
+const days = DAYS
 
 onMounted(async () => {
   if (companyId) {
@@ -149,15 +150,7 @@ function dayStatus(day) {
 }
 
 function dayLabel(day) {
-  return {
-    monday: 'Mo',
-    tuesday: 'Di',
-    wednesday: 'Mi',
-    thursday: 'Do',
-    friday: 'Fr',
-    saturday: 'Sa',
-    sunday: 'So'
-  }[day] || day
+  return DAY_LABELS[day] || day
 }
 
 function formatTimeRange(range) {

--- a/src/stores/company.js
+++ b/src/stores/company.js
@@ -1,6 +1,7 @@
 import { ref, computed } from 'vue'
 import { getCompanies } from '@/services/company'
 import { filters } from './filters'
+import { DAYS } from '@/constants/days'
 
 const companies = ref([])
 const loading = ref(false)
@@ -16,8 +17,6 @@ export async function fetchCompanies() {
   }
 }
 
-const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
-
 export const filteredCompanies = computed(() => {
   const now = new Date()
   const currentMinutes = now.getHours() * 60 + now.getMinutes()
@@ -30,7 +29,7 @@ export const filteredCompanies = computed(() => {
       try {
         let dayIndex = now.getDay() - 1
         if (dayIndex < 0) dayIndex = 6
-        const today = days[dayIndex]
+        const today = DAYS[dayIndex]
         const hours = company.opening_hours?.[today]
         if (hours?.open && hours?.close) {
           const [oh, om] = hours.open.split(':').map(Number)


### PR DESCRIPTION
## Summary
- add reusable day constants
- use shared day labels across components and store

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689da697c10c8321be280ef39a9d938b