### PR TITLE
chore: tighten company update Firestore rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,7 +5,8 @@ service cloud.firestore {
       // Owners can manage their own company profile
       allow create: if request.auth != null && request.auth.uid == companyId;
       allow read: if resource.data.verified == true || (request.auth != null && request.auth.uid == companyId);
-      allow update, delete: if request.auth != null && request.auth.uid == companyId;
+      allow update: if request.auth != null && request.auth.uid == companyId && request.resource.data.verified == resource.data.verified;
+      allow delete: if request.auth != null && request.auth.uid == companyId;
     }
 
     match /notify_me/{docId} {


### PR DESCRIPTION
## Summary
- prevent companies from altering their verified status
- split update/delete permissions for clearer control

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dab3e16388321a91d3d68ff1462b6