### PR TITLE
feat: add password strength indicator and autofill

### DIFF
--- a/src/components/common/PasswordField.vue
+++ b/src/components/common/PasswordField.vue
@@ -1,0 +1,81 @@
+<template>
+  <div>
+    <FormKit
+      type="password"
+      :name="name"
+      :label="label"
+      validation="required|min:8"
+      :placeholder="placeholder"
+      :classes="inputClasses"
+      :autocomplete="autocomplete"
+      v-model="innerValue"
+    />
+    <div v-if="innerValue" :class="['text-sm mt-1', strengthClass]">
+      Passwortstärke: {{ strengthText }}
+    </div>
+    <button
+      type="button"
+      class="text-xs text-gold underline mt-1"
+      @click="generate"
+    >
+      Passwort generieren
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+
+const props = defineProps({
+  name: { type: String, default: 'password' },
+  label: { type: String, default: 'Passwort' },
+  placeholder: { type: String, default: 'Mind. 8 Zeichen' },
+  modelValue: { type: String, default: '' },
+  autocomplete: { type: String, default: 'new-password' }
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const innerValue = ref(props.modelValue)
+watch(innerValue, (val) => emit('update:modelValue', val))
+
+const inputClasses = {
+  label: 'block text-sm font-medium mb-1',
+  input: 'w-full border border-gray-300 rounded-xl px-3 py-2 focus:ring-2 focus:ring-gold focus:border-gold'
+}
+
+function generate() {
+  const chars =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+-=[]{}|;:,./<>?'
+  let pwd = ''
+  for (let i = 0; i < 12; i++) {
+    pwd += chars[Math.floor(Math.random() * chars.length)]
+  }
+  innerValue.value = pwd
+}
+
+const strength = computed(() => {
+  const v = innerValue.value || ''
+  let score = 0
+  if (v.length >= 8) score++
+  if (/[A-Z]/.test(v)) score++
+  if (/[0-9]/.test(v)) score++
+  if (/[^A-Za-z0-9]/.test(v)) score++
+  return score
+})
+
+const strengthText = computed(() => {
+  const s = strength.value
+  if (s <= 1) return 'Schwach'
+  if (s === 2 || s === 3) return 'Mittel'
+  return 'Stark'
+})
+
+const strengthClass = computed(() => {
+  const s = strength.value
+  if (s <= 1) return 'text-red-500'
+  if (s === 2 || s === 3) return 'text-yellow-500'
+  return 'text-green-500'
+})
+</script>
+

--- a/src/pages/company/OnboardingView.vue
+++ b/src/pages/company/OnboardingView.vue
@@ -34,14 +34,7 @@
           :classes="{ label: 'label', input: 'input' }"
         />
 
-        <FormKit
-          type="password"
-          name="password"
-          label="Passwort"
-          validation="required|min:6"
-          placeholder="Mind. 6 Zeichen"
-          :classes="{ label: 'label', input: 'input' }"
-        />
+        <PasswordField />
 
         <FormKit
           type="password"
@@ -50,6 +43,7 @@
           validation="required|confirm:password"
           placeholder="Nochmals eingeben"
           :classes="{ label: 'label', input: 'input' }"
+          autocomplete="new-password"
         />
 
         <FormKit
@@ -228,6 +222,7 @@ import { auth, db } from '@/firebase'
 import { createUserWithEmailAndPassword, updateEmail } from 'firebase/auth'
 import { doc, setDoc, updateDoc } from 'firebase/firestore'
 import Button from '@/components/common/Button.vue'
+import PasswordField from '@/components/common/PasswordField.vue'
 import OpeningHoursForm from '@/components/company/OpeningHoursForm.vue'
 import { LOCK_TYPE_OPTIONS } from '@/constants/lockTypes'
 import { sendVerificationEmail } from '@/services/auth'

--- a/src/pages/company/RegisterView.vue
+++ b/src/pages/company/RegisterView.vue
@@ -33,14 +33,7 @@
           :classes="{ label: 'label', input: 'input' }"
         />
 
-        <FormKit
-          type="password"
-          name="password"
-          label="Passwort"
-          validation="required|min:6"
-          placeholder="Mind. 6 Zeichen"
-          :classes="{ label: 'label', input: 'input' }"
-        />
+        <PasswordField />
 
         <FormKit
           type="password"
@@ -49,6 +42,7 @@
           validation="required|confirm:password"
           placeholder="Nochmals eingeben"
           :classes="{ label: 'label', input: 'input' }"
+          autocomplete="new-password"
         />
 
         <FormKit
@@ -140,6 +134,7 @@ import { auth, db } from '@/firebase'
 import { createUserWithEmailAndPassword } from 'firebase/auth'
 import { doc, setDoc } from 'firebase/firestore'
 import Button from '@/components/common/Button.vue'
+import PasswordField from '@/components/common/PasswordField.vue'
 import OpeningHoursForm from '@/components/company/OpeningHoursForm.vue'
 import { LOCK_TYPE_OPTIONS } from '@/constants/lockTypes'
 


### PR DESCRIPTION
## Summary
- add reusable `PasswordField` component with strength meter and generator
- integrate enhanced password field into onboarding and registration flows
- enable password autofill for confirmation fields

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dae29a56c8321b212fb3d9c5e9f59