### PR TITLE
Reload user after applying email verification

### DIFF
--- a/src/pages/VerifyEmailView.vue
+++ b/src/pages/VerifyEmailView.vue
@@ -41,7 +41,9 @@ onMounted(async () => {
   try {
     const info = await checkActionCode(auth, code)
     await applyActionCode(auth, code)
+    // Reload the current user so emailVerified is updated locally
     if (auth.currentUser) {
+      await auth.currentUser.reload()
       await updateDoc(doc(db, 'companies', auth.currentUser.uid), { verified: true })
     } else if (info?.data?.email) {
       const q = query(collection(db, 'companies'), where('email', '==', info.data.email))


### PR DESCRIPTION
## Summary
- Reload user after applying email verification code so emailVerified updates locally

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689daf0b55648321823a2c0b86495017