### PR TITLE
fix: prevent opening-hours time freeze

### DIFF
--- a/src/components/company/OpeningHoursForm.vue
+++ b/src/components/company/OpeningHoursForm.vue
@@ -52,9 +52,20 @@ watch(
     if (!val) return
     const keys = Object.keys(val)
     if (keys.length) {
-      selectedDays.value = keys
-      open.value = val[keys[0]]?.open || ''
-      close.value = val[keys[0]]?.close || ''
+      // only update selected days if they actually changed
+      if (
+        keys.length !== selectedDays.value.length ||
+        keys.some((k, i) => k !== selectedDays.value[i])
+      ) {
+        selectedDays.value = keys
+      }
+      const first = val[keys[0]] || {}
+      if (open.value !== first.open) {
+        open.value = first.open || ''
+      }
+      if (close.value !== first.close) {
+        close.value = first.close || ''
+      }
     }
   },
   { immediate: true }


### PR DESCRIPTION
## Summary
- prevent infinite update loop when editing opening hours

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dbe16ae8c8321b7ff231987dc7f78