### PR TITLE
refactor: split heavy libs into chunks

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -22,4 +22,17 @@ export default defineConfig({
       'lucide-vue-next': path.resolve(__dirname, './src/components/icons'),
     },
   },
+  build: {
+    // Split heavy dependencies into separate chunks to keep the main bundle small
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          firebase: ['firebase/app', 'firebase/auth', 'firebase/firestore', 'firebase/storage'],
+          formkit: ['@formkit/vue', '@formkit/core', '@formkit/themes'],
+        },
+      },
+    },
+    // Increase the limit to avoid warnings when chunks are still large
+    chunkSizeWarningLimit: 1000,
+  },
 })


### PR DESCRIPTION
## Summary
- split firebase and formkit into separate rollup chunks
- increase chunk size warning limit to 1000

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dc2e9b5b0832198b5e2f39c83f595