### PR TITLE
feat: handle password reset links

### DIFF
--- a/src/pages/ResetPasswordConfirmView.vue
+++ b/src/pages/ResetPasswordConfirmView.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="flex flex-col items-center justify-center text-center min-h-[60vh] px-4">
+    <template v-if="loading">
+      <Loader :size="80" />
+      <p class="mt-2">Überprüfe Link...</p>
+    </template>
+    <template v-else-if="success">
+      <lottie-player
+        src="/lotties/haken.json"
+        background="transparent"
+        speed="1"
+        style="width: 200px; height: 200px;"
+        autoplay
+      ></lottie-player>
+      <h1 class="text-2xl font-semibold text-black mt-4">Passwort geändert</h1>
+      <button class="btn mt-6" @click="gotoLogin">Weiter zum Login</button>
+    </template>
+    <template v-else-if="valid">
+      <FormKit
+        type="form"
+        :actions="false"
+        @submit="updatePassword"
+        :config="{ validationVisibility: 'live' }"
+      >
+        <FormKit
+          type="password"
+          name="password"
+          label="Neues Passwort"
+          validation="required|length:6,36"
+          v-model="newPassword"
+          :classes="{ label: 'label', input: 'input' }"
+        />
+        <p v-if="error" class="text-red-600 text-sm">{{ error }}</p>
+        <Button :disabled="submitting" class="w-full mt-4">
+          <template v-if="submitting">
+            <Loader :size="20" />
+          </template>
+          <span v-else>Passwort setzen</span>
+        </Button>
+      </FormKit>
+    </template>
+    <p v-else class="text-red-600">Link ist ungültig oder abgelaufen.</p>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { auth } from '@/firebase'
+import { verifyPasswordResetCode, confirmPasswordReset } from 'firebase/auth'
+import Button from '@/components/common/Button.vue'
+import Loader from '@/components/common/Loader.vue'
+
+const route = useRoute()
+const router = useRouter()
+const loading = ref(true)
+const valid = ref(false)
+const success = ref(false)
+const submitting = ref(false)
+const newPassword = ref('')
+const error = ref('')
+
+onMounted(async () => {
+  const code = route.query.oobCode
+  if (!code) {
+    loading.value = false
+    return
+  }
+  try {
+    await verifyPasswordResetCode(auth, code)
+    valid.value = true
+  } catch (err) {
+    console.error('Passwort-Reset-Code ungültig', err)
+  } finally {
+    loading.value = false
+  }
+})
+
+async function updatePassword() {
+  if (submitting.value) return
+  submitting.value = true
+  error.value = ''
+  try {
+    const code = route.query.oobCode
+    await confirmPasswordReset(auth, code, newPassword.value)
+    success.value = true
+    valid.value = false
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    submitting.value = false
+  }
+}
+
+function gotoLogin() {
+  router.push('/login')
+}
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -22,6 +22,11 @@ const routes = [
       { path: 'onboarding', name: 'onboarding', component: () => import('@/pages/company/OnboardingView.vue') },
       { path: 'reset-password', name: 'reset-password', component: () => import('@/pages/ResetPasswordView.vue') },
       {
+        path: 'reset-password/confirm',
+        name: 'reset-password-confirm',
+        component: () => import('@/pages/ResetPasswordConfirmView.vue'),
+      },
+      {
         path: 'dashboard',
         name: 'dashboard',
         component: () => import('@/pages/company/DashboardView.vue'),

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -12,7 +12,14 @@ export async function login(email, password) {
 }
 
 export async function resetPassword(email) {
-  return sendPasswordResetEmail(auth, email)
+  const baseUrl =
+    import.meta.env.VITE_PUBLIC_URL ||
+    (typeof window !== 'undefined' ? window.location.origin : '')
+  const actionCodeSettings = {
+    url: baseUrl + '/reset-password/confirm',
+    handleCodeInApp: true,
+  }
+  return sendPasswordResetEmail(auth, email, actionCodeSettings)
 }
 
 export async function logout() {

--- a/src/services/auth.test.js
+++ b/src/services/auth.test.js
@@ -27,7 +27,10 @@ describe('auth service', () => {
 
   it('resetPassword calls firebase sendPasswordResetEmail', async () => {
     await resetPassword('mail@example.com')
-    expect(sendPasswordResetEmail).toHaveBeenCalledWith('auth-instance', 'mail@example.com')
+    expect(sendPasswordResetEmail).toHaveBeenCalledWith('auth-instance', 'mail@example.com', {
+      url: '/reset-password/confirm',
+      handleCodeInApp: true,
+    })
   })
 
   it('logout calls firebase signOut', async () => {


### PR DESCRIPTION
## Summary
- add page to confirm password resets via Firebase action code
- send reset emails to custom confirmation page
- add route and tests for reset password flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dcbe1784c8321acf50b26c65db439