### PR TITLE
feat: ensure magikey.de registration

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -14,7 +14,7 @@ export async function login(email, password) {
 export async function resetPassword(email) {
   const baseUrl =
     import.meta.env.VITE_PUBLIC_URL ||
-    (typeof window !== 'undefined' ? window.location.origin : '')
+    (typeof window !== 'undefined' ? window.location.origin : 'https://magikey.de')
   const actionCodeSettings = {
     url: baseUrl + '/reset-password/confirm',
     handleCodeInApp: true,
@@ -34,7 +34,7 @@ export async function sendVerificationEmail(user = auth.currentUser) {
   if (!user) throw new Error('No user')
   const baseUrl =
     import.meta.env.VITE_PUBLIC_URL ||
-    (typeof window !== 'undefined' ? window.location.origin : '')
+    (typeof window !== 'undefined' ? window.location.origin : 'https://magikey.de')
   const actionCodeSettings = {
     url: baseUrl + '/verify',
     handleCodeInApp: true,

--- a/src/services/auth.test.js
+++ b/src/services/auth.test.js
@@ -28,7 +28,7 @@ describe('auth service', () => {
   it('resetPassword calls firebase sendPasswordResetEmail', async () => {
     await resetPassword('mail@example.com')
     expect(sendPasswordResetEmail).toHaveBeenCalledWith('auth-instance', 'mail@example.com', {
-      url: '/reset-password/confirm',
+      url: 'https://magikey.de/reset-password/confirm',
       handleCodeInApp: true,
     })
   })
@@ -46,7 +46,10 @@ describe('auth service', () => {
   it('sendVerificationEmail calls firebase sendEmailVerification', async () => {
     const user = { uid: '1' }
     await sendVerificationEmail(user)
-    expect(sendEmailVerification).toHaveBeenCalled()
+    expect(sendEmailVerification).toHaveBeenCalledWith(user, {
+      url: 'https://magikey.de/verify',
+      handleCodeInApp: true,
+    })
   })
 })
 


### PR DESCRIPTION
## Summary
- ensure auth emails default to `https://magikey.de`
- update auth service tests for new base URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dcdc2d7ec832185133c5de0e43fa9