### PR TITLE
Fix email verification redirect

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -12,11 +12,8 @@ export async function login(email, password) {
 }
 
 export async function resetPassword(email) {
-  const baseUrl =
-    import.meta.env.VITE_PUBLIC_URL ||
-    (typeof window !== 'undefined' ? window.location.origin : 'https://magikey.de')
   const actionCodeSettings = {
-    url: baseUrl + '/reset-password/confirm',
+    url: 'https://magikey.de/reset-password/confirm',
     handleCodeInApp: true,
   }
   return sendPasswordResetEmail(auth, email, actionCodeSettings)
@@ -32,11 +29,8 @@ export async function register(email, password) {
 
 export async function sendVerificationEmail(user = auth.currentUser) {
   if (!user) throw new Error('No user')
-  const baseUrl =
-    import.meta.env.VITE_PUBLIC_URL ||
-    (typeof window !== 'undefined' ? window.location.origin : 'https://magikey.de')
   const actionCodeSettings = {
-    url: baseUrl + '/verify',
+    url: 'https://magikey.de/verify',
     handleCodeInApp: true,
   }
   return sendEmailVerification(user, actionCodeSettings)


### PR DESCRIPTION
## Summary
- Use magikey.de for password reset email links
- Always send verification emails to magikey.de/verify

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dd12f27988321b0ab77a6f5482254