### PR TITLE
Prevent duplicate company creation

### DIFF
--- a/src/pages/company/OnboardingView.vue
+++ b/src/pages/company/OnboardingView.vue
@@ -236,7 +236,7 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { auth, db } from '@/firebase'
 import { createUserWithEmailAndPassword } from 'firebase/auth'
-import { doc, setDoc, updateDoc } from 'firebase/firestore'
+import { doc, setDoc, updateDoc, getDoc } from 'firebase/firestore'
 import Button from '@/components/common/Button.vue'
 import PasswordField from '@/components/common/PasswordField.vue'
 import OpeningHoursForm from '@/components/company/OpeningHoursForm.vue'
@@ -299,23 +299,27 @@ async function register() {
       )
       user = cred.user
     }
-    await setDoc(doc(db, 'companies', user.uid), {
-      company_name: form.value.company_name,
-      email: form.value.email,
-      phone: form.value.phone,
-      address: form.value.address,
-      city: form.value.city,
-      postal_code: form.value.postal_code,
-      price: form.value.price,
-      description: form.value.description,
-      lock_types: form.value.lock_types,
-      opening_hours: form.value.opening_hours,
-      is_247: form.value.is_247,
-      emergency_price: form.value.is_247 ? form.value.emergency_price || '' : '',
-      logo_url: form.value.logo_url || '',
-      created_at: new Date().toISOString(),
-      verified: false,
-    })
+    const companyRef = doc(db, 'companies', user.uid)
+    const existing = await getDoc(companyRef)
+    if (!existing.exists()) {
+      await setDoc(companyRef, {
+        company_name: form.value.company_name,
+        email: form.value.email,
+        phone: form.value.phone,
+        address: form.value.address,
+        city: form.value.city,
+        postal_code: form.value.postal_code,
+        price: form.value.price,
+        description: form.value.description,
+        lock_types: form.value.lock_types,
+        opening_hours: form.value.opening_hours,
+        is_247: form.value.is_247,
+        emergency_price: form.value.is_247 ? form.value.emergency_price || '' : '',
+        logo_url: form.value.logo_url || '',
+        created_at: new Date().toISOString(),
+        verified: false,
+      })
+    }
     step.value = 7
   } catch (e) {
     alert('Fehler bei der Registrierung: ' + e.message)

--- a/src/pages/company/RegisterView.vue
+++ b/src/pages/company/RegisterView.vue
@@ -132,7 +132,7 @@ import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { auth, db } from '@/firebase'
 import { createUserWithEmailAndPassword } from 'firebase/auth'
-import { doc, setDoc } from 'firebase/firestore'
+import { doc, setDoc, getDoc } from 'firebase/firestore'
 import Button from '@/components/common/Button.vue'
 import PasswordField from '@/components/common/PasswordField.vue'
 import OpeningHoursForm from '@/components/company/OpeningHoursForm.vue'
@@ -153,22 +153,26 @@ const register = async (form) => {
       form.email,
       form.password
     )
-    await setDoc(doc(db, 'companies', user.uid), {
-      company_name: form.company_name,
-      email: form.email,
-      phone: form.phone,
-      address: form.address || '',
-      city: form.city || '',
-      postal_code: form.postal_code || '',
-      price: form.price || '',
-      description: form.description || '',
-      lock_types: lockTypes.value,
-      opening_hours: openingHours.value,
-      is_247: form.is_247 || false,
-      emergency_price: form.is_247 ? form.emergency_price || '' : '',
-      created_at: new Date().toISOString(),
-      verified: false,
-    })
+    const companyRef = doc(db, 'companies', user.uid)
+    const existing = await getDoc(companyRef)
+    if (!existing.exists()) {
+      await setDoc(companyRef, {
+        company_name: form.company_name,
+        email: form.email,
+        phone: form.phone,
+        address: form.address || '',
+        city: form.city || '',
+        postal_code: form.postal_code || '',
+        price: form.price || '',
+        description: form.description || '',
+        lock_types: lockTypes.value,
+        opening_hours: openingHours.value,
+        is_247: form.is_247 || false,
+        emergency_price: form.is_247 ? form.emergency_price || '' : '',
+        created_at: new Date().toISOString(),
+        verified: false,
+      })
+    }
     await sendVerificationEmail(user)
     router.push({
       name: 'success',


### PR DESCRIPTION
## Summary
- avoid double company entries by checking if Firestore document exists before creating

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dd54133a4832192a82c503a75e840