### PR TITLE
Relax password validation to accept any 6+ character value

### DIFF
--- a/src/components/common/PasswordField.vue
+++ b/src/components/common/PasswordField.vue
@@ -5,7 +5,7 @@
       type="password"
       :name="name"
       :label="label"
-      validation="required|min:6|matches:/^(?=.*[A-Za-z])(?=.*\d).*$/"
+      validation="required|min:6"
       :placeholder="placeholder"
       :help="help"
       :classes="inputClasses"
@@ -38,7 +38,7 @@ const props = defineProps({
   help: {
     type: String,
     default:
-      'Mindestens 6 Zeichen, Groß- und Kleinbuchstaben, Zahl und Sonderzeichen',
+      'Mindestens 6 Zeichen. Verwende nach Möglichkeit Groß- und Kleinbuchstaben, Zahlen und Sonderzeichen.',
   },
   modelValue: { type: String, default: '' },
   autocomplete: { type: String, default: 'new-password' },


### PR DESCRIPTION
## Summary
- allow passwords with any characters as long as they have at least six characters during registration
- keep the password strength indicator but adjust helper text to recommend stronger passwords without enforcing the rule

## Testing
- `npm run test` *(fails: existing Vitest suites expect mocked firebase exports)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b7213cf08321b7514888ffa66050