### PR TITLE
Soften search result hover highlight

### DIFF
--- a/src/components/user/SearchResultTile.vue
+++ b/src/components/user/SearchResultTile.vue
@@ -118,17 +118,19 @@ function navigateToDetails() {
 .result-tile::before {
   content: '';
   position: absolute;
-  width: 160%;
-  height: 160%;
-  top: -45%;
-  right: -25%;
-  background: radial-gradient(circle at 35% 35%, rgba(217, 169, 8, 0.18), transparent 65%);
-  transform: scale(0);
-  transition: transform 0.6s ease;
+  width: 130%;
+  height: 130%;
+  top: -40%;
+  right: -20%;
+  background: radial-gradient(circle at 35% 35%, rgba(217, 169, 8, 0.12), transparent 60%);
+  opacity: 0;
+  transform: scale(0.65);
+  transition: transform 0.45s ease, opacity 0.45s ease;
 }
 
 .result-tile:hover::before {
-  transform: scale(1);
+  opacity: 1;
+  transform: scale(0.95);
 }
 
 .result-tile:hover {


### PR DESCRIPTION
## Summary
- tone down the hover highlight overlay on search result tiles to avoid a full yellow flash
- add a subtle opacity and scale transition for a softer card emphasis effect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7b77022688321aa626a43443f10d2