### PR TITLE
Refine header search bar styling and remove hero badge

### DIFF
--- a/src/components/user/FilterBar.vue
+++ b/src/components/user/FilterBar.vue
@@ -1,20 +1,29 @@
 <!-- Diese Datei baut die große Filterleiste für die Desktop-Ansicht auf. -->
 <template>
-  <div ref="root" class="sticky top-2 z-30 flex justify-center px-2 min-w-0" @click.self="activeField = null">
+  <div ref="root" class="sticky top-2 z-30 flex min-w-0 justify-center px-2" @click.self="activeField = null">
     <div
-      class="flex w-full max-w-5xl items-center divide-x overflow-hidden rounded-full border border-gray-100 bg-white/80 px-4 py-3 text-base shadow-lg backdrop-blur transition-all duration-200 sm:py-2 sm:text-sm min-w-0"
-      :class="{ 'scale-105 py-3': expanded }"
+      class="group/search relative flex w-full max-w-5xl items-center overflow-hidden rounded-full border border-white/70 bg-gradient-to-r from-white/95 via-white/85 to-white/70 px-3 py-3 text-base text-slate-700 shadow-xl backdrop-blur-xl transition-all duration-300 sm:px-4 sm:py-2 sm:text-sm"
+      :class="{
+        'scale-[1.02] ring-2 ring-gold/40 shadow-2xl': expanded || hasFocus,
+      }"
     >
+      <div class="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover/search:opacity-100">
+        <div class="absolute inset-0 bg-white/30"></div>
+        <div class="absolute inset-x-6 top-0 h-1 rounded-full bg-gradient-to-r from-gold/20 via-transparent to-gold/20"></div>
+      </div>
       <div
-        class="relative flex flex-1 min-w-0 items-center gap-2 py-3 px-4 transition-all duration-200 sm:py-2"
-        :class="{ 'z-10 scale-105 bg-white': activeField === 'location' || filters.location }"
+        class="group/location relative z-10 flex min-w-0 flex-1 items-center gap-3 rounded-full py-3 pl-4 pr-5 transition-all duration-200 sm:py-2"
+        :class="{
+          'bg-white shadow-inner ring-1 ring-gold/30': activeField === 'location' || filters.location,
+          'hover:bg-white/80': !filters.location,
+        }"
         @click.stop="activeField = 'location'"
       >
         <MapPin class="h-5 w-5 text-gold" />
         <input
           v-model="filters.location"
           placeholder="Wo?"
-          class="flex-1 min-w-0 border-none bg-transparent text-base placeholder:text-gray-400 focus:ring-0 sm:text-sm"
+          class="flex-1 min-w-0 border-none bg-transparent text-base placeholder:text-slate-400 focus:ring-0 sm:text-sm"
           autocomplete="postal-code"
           @focus="activeField = 'location'"
         />
@@ -26,9 +35,11 @@
           <X class="h-3 w-3" />
         </button>
       </div>
+      <div class="hidden h-9 w-px bg-white/60 sm:block"></div>
+
       <button
-        class="relative flex items-center gap-2 py-3 px-4 text-base transition-all duration-200 hover:bg-gray-50 sm:py-2 sm:text-sm"
-        :class="{ 'z-10 scale-105 bg-white text-gold': activeField === 'openNow' || filters.openNow }"
+        class="relative z-10 flex items-center gap-2 rounded-full py-3 px-4 text-base transition-all duration-200 hover:bg-white/70 hover:text-slate-900 sm:py-2 sm:text-sm"
+        :class="{ 'bg-white text-gold shadow-inner ring-1 ring-gold/30': activeField === 'openNow' || filters.openNow }"
         @click.stop="toggleFilter('openNow'); activeField = 'openNow'"
       >
         <Clock class="h-5 w-5" />
@@ -37,9 +48,10 @@
           <X class="h-3 w-3" />
         </span>
       </button>
+
       <button
-        class="relative flex items-center gap-2 py-3 px-4 text-base transition-all duration-200 hover:bg-gray-50 sm:py-2 sm:text-sm"
-        :class="{ 'z-10 scale-105 bg-white text-gold': activeField === 'price' || priceActive }"
+        class="relative z-10 flex items-center gap-2 rounded-full py-3 px-4 text-base transition-all duration-200 hover:bg-white/70 hover:text-slate-900 sm:py-2 sm:text-sm"
+        :class="{ 'bg-white text-gold shadow-inner ring-1 ring-gold/30': activeField === 'price' || priceActive }"
         @click.stop="openPrice"
       >
         <Euro class="h-5 w-5" />
@@ -50,9 +62,10 @@
         </span>
         <ChevronDown v-else class="h-4 w-4" />
       </button>
+
       <button
-        class="relative flex items-center gap-2 py-3 px-4 text-base transition-all duration-200 hover:bg-gray-50 sm:py-2 sm:text-sm"
-        :class="{ 'z-10 scale-105 bg-white text-gold': activeField === 'lockTypes' || filters.lockTypes.length }"
+        class="relative z-10 flex items-center gap-2 rounded-full py-3 px-4 text-base transition-all duration-200 hover:bg-white/70 hover:text-slate-900 sm:py-2 sm:text-sm"
+        :class="{ 'bg-white text-gold shadow-inner ring-1 ring-gold/30': activeField === 'lockTypes' || filters.lockTypes.length }"
         @click.stop="openLockTypes"
       >
         <Lock class="h-5 w-5" />
@@ -63,15 +76,15 @@
         </span>
         <ChevronDown v-else class="h-4 w-4" />
       </button>
-      <div class="flex flex-shrink-0 justify-end py-3 pl-4 pr-4 sm:py-0">
+      <div class="flex flex-shrink-0 items-center justify-end py-3 pl-4 pr-2 sm:py-0">
         <button
-          class="group relative overflow-hidden rounded-full bg-gold p-2 text-white shadow-md transition-all duration-300 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-gold/60"
-          aria-label="Suchen"
+          class="group relative flex items-center gap-2 overflow-hidden rounded-full bg-gradient-to-r from-gold to-amber-500 px-5 py-2 text-sm font-semibold uppercase tracking-wide text-white shadow-lg transition-all duration-300 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-amber-200"
         >
           <span class="relative z-10">
             <Search class="h-4 w-4" />
           </span>
-          <span class="absolute inset-0 scale-0 rounded-full bg-white/40 transition-transform duration-500 ease-out group-hover:scale-125 group-active:scale-150"></span>
+          <span class="relative z-10 hidden sm:inline">Suchen</span>
+          <span class="absolute inset-0 scale-0 rounded-full bg-white/30 transition-transform duration-500 ease-out group-hover:scale-125 group-active:scale-150"></span>
         </button>
       </div>
     </div>
@@ -102,6 +115,14 @@ const showPrice = ref(false)
 const showLockTypes = ref(false)
 const activeField = ref(null)
 const priceActive = computed(() => filters.price[0] !== 0 || filters.price[1] !== 1000)
+const hasFocus = computed(() => {
+  if (activeField.value) return true
+  if (filters.location) return true
+  if (filters.openNow) return true
+  if (priceActive.value) return true
+  if (filters.lockTypes.length) return true
+  return false
+})
 
 watch(activeField, (val) => {
   if (val) {

--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -16,9 +16,6 @@
             <h1 class="text-3xl font-semibold text-slate-900 sm:text-4xl">
               {{ headline }}
             </h1>
-            <span class="rounded-full bg-gold/15 px-3 py-1 text-xs font-medium text-gold">
-              Beta
-            </span>
           </div>
           <p class="max-w-3xl text-base leading-relaxed text-slate-600 sm:text-lg">
             Finde vertrauenswürdige Schlüsseldienste in deiner Nähe – transparent, schnell und mit


### PR DESCRIPTION
## Summary
- polish the desktop filter bar with a brighter gradient shell, pill controls, and updated action button
- track focus state so the search bar rings consistently when filters are active
- remove the beta badge from the home hero headline

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7d7c0853c83219780ca3e9ca3ba31