### PR TITLE
Improve postal code filtering in company store

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,6 +20,7 @@ export default [
         alert: 'readonly',
         confirm: 'readonly',
         navigator: 'readonly',
+        Intl: 'readonly',
       },
     },
     plugins: { vue },

--- a/src/stores/company.js
+++ b/src/stores/company.js
@@ -22,8 +22,20 @@ export const filteredCompanies = computed(() => {
   const now = new Date()
   const currentMinutes = now.getHours() * 60 + now.getMinutes()
 
+  const normalizedLocation = filters.location?.toString().trim()
+  const normalizedLocationDigits = normalizedLocation?.replace(/\s+/g, '')
+  const normalizedLocationLower = normalizedLocation?.toLowerCase()
+
   return companies.value.filter((company) => {
-    const matchesPLZ = company.postal_code?.includes(filters.location)
+    const postalCode = company.postal_code != null ? company.postal_code.toString().trim() : ''
+    const normalizedPostalCode = postalCode.replace(/\s+/g, '')
+    const matchesPLZ =
+      !normalizedLocationDigits ||
+      normalizedPostalCode.includes(normalizedLocationDigits)
+    const city = company.city != null ? company.city.toString().toLowerCase() : ''
+    const matchesCity = normalizedLocationLower
+      ? city.includes(normalizedLocationLower)
+      : false
 
     let isOpen = true
     if (filters.openNow) {
@@ -54,7 +66,7 @@ export const filteredCompanies = computed(() => {
       filters.lockTypes.length === 0 ||
       (company.lock_types || []).some((t) => filters.lockTypes.includes(t))
 
-    return matchesPLZ && matchesOpen && inPrice && matchesLock
+    return (matchesPLZ || matchesCity) && matchesOpen && inPrice && matchesLock
   })
 })
 


### PR DESCRIPTION
## Summary
- normalize the location filter before matching company postal codes and cities
- fall back to city name matches so mixed postal code or city input still yields results
- declare Intl as a global in the ESLint config to keep linting green

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7d96b41408321af8b7f5dd8563e68