### PR TITLE
Improve location handling in search bar

### DIFF
--- a/src/components/user/IntroPopup.vue
+++ b/src/components/user/IntroPopup.vue
@@ -57,7 +57,16 @@ const emit = defineEmits(['close'])
 
 function applyPostal() {
   if (postal.value.trim()) {
-    filters.location = postal.value.trim()
+    const label = postal.value.trim()
+    filters.location = label
+    filters.locationMeta = {
+      label,
+      postalCode: label,
+      city: '',
+      lat: null,
+      lng: null,
+      source: 'intro'
+    }
     emit('close')
   }
 }

--- a/src/composables/useLocationSearch.js
+++ b/src/composables/useLocationSearch.js
@@ -1,0 +1,135 @@
+/* global setTimeout, clearTimeout, AbortController */
+// Gemeinsamer Hook für die Standortsuche in Desktop- und Mobilansicht.
+import { ref, watch } from 'vue'
+import { filters } from '@/stores/filters'
+import { searchLocations, detectCurrentLocation } from '@/services/location'
+
+export function useLocationSearch() {
+  const query = ref(filters.location)
+  const suggestions = ref([])
+  const loadingSuggestions = ref(false)
+  const suggestionsError = ref('')
+  const geolocationPending = ref(false)
+
+  let abortController = null
+  let debounceTimeout = null
+
+  watch(
+    () => filters.location,
+    (value) => {
+      const next = value || ''
+      if (next !== query.value) {
+        query.value = next
+      }
+    }
+  )
+
+  watch(query, (value) => {
+    const normalized = value?.toString() ?? ''
+    if (filters.location !== normalized) {
+      filters.location = normalized
+    }
+    if (filters.locationMeta && filters.locationMeta.label !== normalized) {
+      filters.locationMeta = null
+    }
+
+    if (debounceTimeout) clearTimeout(debounceTimeout)
+
+    const trimmed = normalized.trim()
+    if (!trimmed || trimmed.length < 2) {
+      if (abortController) {
+        abortController.abort()
+        abortController = null
+      }
+      suggestions.value = []
+      suggestionsError.value = ''
+      return
+    }
+
+    debounceTimeout = setTimeout(() => fetchSuggestions(trimmed), 250)
+  })
+
+  async function fetchSuggestions(term) {
+    if (abortController) {
+      abortController.abort()
+    }
+
+    abortController = typeof AbortController !== 'undefined' ? new AbortController() : null
+
+    loadingSuggestions.value = true
+    suggestionsError.value = ''
+
+    try {
+      const results = await searchLocations(term, { signal: abortController?.signal })
+      suggestions.value = results
+      if (!results.length) {
+        suggestionsError.value = 'Keine passenden Orte gefunden'
+      }
+    } catch (error) {
+      if (error?.name === 'AbortError') return
+      console.error('Ortssuche fehlgeschlagen:', error)
+      suggestions.value = []
+      suggestionsError.value = 'Ortssuche aktuell nicht verfügbar'
+    } finally {
+      loadingSuggestions.value = false
+    }
+  }
+
+  function applyLocation(location) {
+    if (!location) return
+    const label = location.label || ''
+    query.value = label
+    filters.location = label
+    filters.locationMeta = {
+      label,
+      postalCode: location.postalCode || '',
+      city: location.city || '',
+      lat: location.lat ?? null,
+      lng: location.lng ?? null,
+      source: location.source || 'manual'
+    }
+    suggestions.value = []
+    suggestionsError.value = ''
+  }
+
+  async function useCurrentLocation() {
+    if (geolocationPending.value) return null
+
+    geolocationPending.value = true
+    suggestionsError.value = ''
+
+    try {
+      const location = await detectCurrentLocation({ enableHighAccuracy: true, timeout: 12000 })
+      if (location?.label) {
+        applyLocation(location)
+      }
+      return location
+    } catch (error) {
+      console.error('Standort konnte nicht ermittelt werden:', error)
+      suggestionsError.value = 'Standort konnte nicht ermittelt werden'
+      return null
+    } finally {
+      geolocationPending.value = false
+    }
+  }
+
+  function clearSuggestions() {
+    suggestions.value = []
+    suggestionsError.value = ''
+    if (abortController) {
+      abortController.abort()
+      abortController = null
+    }
+  }
+
+  return {
+    query,
+    suggestions,
+    loadingSuggestions,
+    suggestionsError,
+    geolocationPending,
+    applyLocation,
+    useCurrentLocation,
+    clearSuggestions
+  }
+}

--- a/src/services/location.js
+++ b/src/services/location.js
@@ -1,0 +1,158 @@
+/* global fetch, URLSearchParams, navigator */
+// Dienstfunktionen für Standort- und Ortssuche.
+import { getPostalFromCoords } from '@/firebase/functions'
+
+const NOMINATIM_BASE_URL = 'https://nominatim.openstreetmap.org'
+
+function normaliseCity(address = {}) {
+  return (
+    address.city ||
+    address.town ||
+    address.village ||
+    address.hamlet ||
+    address.county ||
+    ''
+  )
+}
+
+function buildLabel({ postalCode, city }) {
+  const trimmedPostal = postalCode?.toString().trim() || ''
+  const trimmedCity = city?.toString().trim() || ''
+  if (trimmedPostal && trimmedCity) return `${trimmedPostal} ${trimmedCity}`
+  if (trimmedPostal) return trimmedPostal
+  if (trimmedCity) return trimmedCity
+  return ''
+}
+
+export async function searchLocations(query, { limit = 6, signal } = {}) {
+  const cleanQuery = query?.toString().trim()
+  if (!cleanQuery) return []
+
+  const params = new URLSearchParams({
+    format: 'jsonv2',
+    addressdetails: '1',
+    limit: limit.toString(),
+    countrycodes: 'de,at,ch',
+    q: cleanQuery,
+    email: 'kontakt@magikey.app'
+  })
+
+  const res = await fetch(`${NOMINATIM_BASE_URL}/search?${params.toString()}`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    signal
+  })
+
+  if (!res.ok) {
+    throw new Error('Ortssuche fehlgeschlagen')
+  }
+
+  const data = await res.json()
+  return data.map((item) => {
+    const address = item.address || {}
+    const postalCode = address.postcode || ''
+    const city = normaliseCity(address)
+    const label = buildLabel({ postalCode, city }) || (item.display_name || '').split(',')[0]?.trim() || ''
+    return {
+      id: item.place_id,
+      label,
+      postalCode,
+      city,
+      lat: Number.parseFloat(item.lat),
+      lng: Number.parseFloat(item.lon),
+      source: 'search'
+    }
+  })
+}
+
+export async function reverseGeocode(lat, lng, { signal } = {}) {
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+    throw new Error('Ungültige Koordinaten')
+  }
+
+  const params = new URLSearchParams({
+    format: 'jsonv2',
+    lat: String(lat),
+    lon: String(lng),
+    addressdetails: '1',
+    zoom: '18',
+    email: 'kontakt@magikey.app'
+  })
+
+  const res = await fetch(`${NOMINATIM_BASE_URL}/reverse?${params.toString()}`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    signal
+  })
+
+  if (!res.ok) {
+    throw new Error('Reverse Geocoding fehlgeschlagen')
+  }
+
+  const data = await res.json()
+  const address = data.address || {}
+  const postalCode = address.postcode || ''
+  const city = normaliseCity(address)
+
+  return {
+    postalCode,
+    city,
+    label: buildLabel({ postalCode, city }),
+    lat,
+    lng,
+    source: 'reverse'
+  }
+}
+
+async function getGeolocationPosition(options) {
+  if (typeof navigator === 'undefined' || !navigator.geolocation) {
+    throw new Error('Geolocation wird nicht unterstützt')
+  }
+
+  return new Promise((resolve, reject) => {
+    navigator.geolocation.getCurrentPosition(resolve, reject, options)
+  })
+}
+
+export async function detectCurrentLocation(options) {
+  const position = await getGeolocationPosition(options)
+  const { latitude, longitude } = position.coords || {}
+
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    throw new Error('Koordinaten nicht verfügbar')
+  }
+
+  let postalCode = ''
+  try {
+    const result = await getPostalFromCoords(latitude, longitude)
+    if (result?.postalCode) postalCode = result.postalCode.toString()
+  } catch (error) {
+    console.warn('Firebase Reverse Geocoding fehlgeschlagen:', error)
+  }
+
+  let reverse
+  try {
+    reverse = await reverseGeocode(latitude, longitude)
+  } catch (error) {
+    if (!postalCode) throw error
+    reverse = {
+      postalCode,
+      city: '',
+      label: postalCode,
+      lat: latitude,
+      lng: longitude,
+      source: 'postal'
+    }
+  }
+
+  const label = buildLabel({ postalCode: reverse.postalCode || postalCode, city: reverse.city })
+
+  return {
+    postalCode: reverse.postalCode || postalCode,
+    city: reverse.city,
+    label,
+    lat: latitude,
+    lng: longitude,
+    source: reverse.source || 'geo'
+  }
+}

--- a/src/stores/filters.js
+++ b/src/stores/filters.js
@@ -5,6 +5,7 @@ export const filters = reactive({
   openNow: false,
   price: [0, 1000],
   location: '',
+  locationMeta: null,
   lockTypes: []
 })
 
@@ -17,6 +18,7 @@ export function clearFilter(key) {
     filters.price = [0, 1000]
   } else if (key === 'location') {
     filters.location = ''
+    filters.locationMeta = null
   } else if (key === 'lockTypes') {
     filters.lockTypes = []
   } else {


### PR DESCRIPTION
## Summary
- add an interactive location picker with geolocation shortcut to the desktop filter bar
- reuse the picker in the mobile filter bar via a shared composable and location service with reverse geocoding fallback
- persist selected locations, including defaults from geolocation, across the home view and intro popup

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7db0123388321a961e2c07fa3d541