### PR TITLE
Improve mobile overlay menu experience

### DIFF
--- a/src/components/common/OverlayMenu.vue
+++ b/src/components/common/OverlayMenu.vue
@@ -1,37 +1,46 @@
 <!-- Dropdown-Menü für Navigation und Aktionen -->
 <template>
-  <transition name="grow-down">
+  <transition name="overlay-fade">
     <div
       v-if="modelValue"
-      class="absolute right-4 top-16 bg-white text-black w-72 max-w-full p-4 rounded-2xl shadow-xl z-50"
+      class="fixed inset-0 z-50 flex items-start justify-end bg-black/30 px-4 pt-20 sm:bg-transparent sm:px-0 sm:pt-0"
+      @click.self="close"
     >
-      <ul class="space-y-3">
-        <li>
-          <router-link to="/hilfe" class="menu-link">Hilfe-Center</router-link>
-        </li>
-        <li v-if="!companyData">
-          <router-link to="/register" class="menu-link">Problemsolver:in werden</router-link>
-        </li>
-        <li>
-          <router-link to="/" class="menu-link">Schlosser finden</router-link>
-        </li>
-        <li v-if="!companyData">
-          <router-link to="/login" class="menu-link">Einloggen</router-link>
-        </li>
-        <li v-if="companyData">
-          <router-link to="/edit" class="menu-link">Profil bearbeiten</router-link>
-        </li>
-        <li v-if="companyData">
-          <button @click="$emit('logout')" class="menu-link w-full text-left">Abmelden</button>
-        </li>
-      </ul>
+      <transition name="grow-down">
+        <div
+          v-if="modelValue"
+          class="menu-panel relative w-full max-w-sm rounded-3xl bg-white p-5 text-black shadow-2xl sm:mr-4 sm:w-72 sm:max-w-full sm:rounded-2xl sm:p-4"
+          @click.stop
+        >
+          <ul class="space-y-3">
+            <li>
+              <router-link to="/hilfe" class="menu-link">Hilfe-Center</router-link>
+            </li>
+            <li v-if="!companyData">
+              <router-link to="/register" class="menu-link">Problemsolver:in werden</router-link>
+            </li>
+            <li>
+              <router-link to="/" class="menu-link">Schlosser finden</router-link>
+            </li>
+            <li v-if="!companyData">
+              <router-link to="/login" class="menu-link">Einloggen</router-link>
+            </li>
+            <li v-if="companyData">
+              <router-link to="/edit" class="menu-link">Profil bearbeiten</router-link>
+            </li>
+            <li v-if="companyData">
+              <button @click="$emit('logout')" class="menu-link w-full text-left">Abmelden</button>
+            </li>
+          </ul>
+        </div>
+      </transition>
     </div>
   </transition>
 </template>
 
 <script setup>
 // Props und Events definieren
-import { watch } from 'vue'
+import { watch, onBeforeUnmount, ref } from 'vue'
 
 const props = defineProps({
   modelValue: Boolean,
@@ -50,20 +59,47 @@ function handleKey(e) {
   if (e.key === 'Escape') close()
 }
 
+const previousBodyOverflow = ref('')
+
 // Listener je nach Sichtbarkeit registrieren
 watch(
   () => props.modelValue,
   (val) => {
     if (val) {
       document.addEventListener('keydown', handleKey)
+      if (typeof window !== 'undefined' && window.innerWidth < 640) {
+        previousBodyOverflow.value = document.body.style.overflow
+        document.body.style.overflow = 'hidden'
+      }
     } else {
       document.removeEventListener('keydown', handleKey)
+      if (typeof window !== 'undefined') {
+        document.body.style.overflow = previousBodyOverflow.value
+      }
     }
   }
 )
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', handleKey)
+  if (typeof window !== 'undefined') {
+    document.body.style.overflow = previousBodyOverflow.value
+  }
+})
 </script>
 
 <style scoped>
+/* Sanfte Einblendung der dunklen Fläche auf kleinen Bildschirmen */
+.overlay-fade-enter-active,
+.overlay-fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.overlay-fade-enter-from,
+.overlay-fade-leave-to {
+  opacity: 0;
+}
+
 /* Dropdown Grow-Down Animation */
 .grow-down-enter-active,
 .grow-down-leave-active {


### PR DESCRIPTION
## Summary
- add a mobile-friendly full-screen treatment for the header overlay menu including background dimming and scroll locking
- prevent accidental menu closure by stopping click propagation inside the menu panel and supporting tap-to-close on the backdrop
- tidy up lifecycle handling by removing global listeners on unmount and restoring body overflow state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7f3c98400832187e58bcf7285bba2