### PR TITLE
Add optional WhatsApp contact for companies

### DIFF
--- a/src/pages/company/DashboardView.vue
+++ b/src/pages/company/DashboardView.vue
@@ -66,6 +66,7 @@
             <div class="grid gap-3 sm:grid-cols-2">
               <DataRow label="E-Mail" :value="company.email || '–'" />
               <DataRow label="Telefon" :value="company.phone || '–'" />
+              <DataRow label="WhatsApp" :value="company.whatsapp || '–'" />
               <DataRow label="Adresse" :value="company.address || '–'" />
               <DataRow label="Ort" :value="company.city || '–'" />
               <DataRow label="PLZ" :value="company.postal_code || '–'" />

--- a/src/pages/company/EditView.vue
+++ b/src/pages/company/EditView.vue
@@ -67,6 +67,14 @@
               :classes="inputClasses"
             />
             <FormKit
+              type="tel"
+              name="whatsapp"
+              label="WhatsApp-Nummer"
+              v-model="company.whatsapp"
+              :classes="inputClasses"
+              help="Optional: Nummer, unter der du per WhatsApp erreichbar bist."
+            />
+            <FormKit
               type="number"
               name="price"
               label="Preis (ab)"
@@ -189,6 +197,7 @@ const currentUser = ref(null)
 const defaultCompany = () => ({
   company_name: '',
   phone: '',
+  whatsapp: '',
   address: '',
   city: '',
   postal_code: '',

--- a/src/pages/company/RegisterView.vue
+++ b/src/pages/company/RegisterView.vue
@@ -82,6 +82,15 @@
               />
 
               <FormKit
+                type="tel"
+                name="whatsapp"
+                label="WhatsApp-Nummer (optional)"
+                placeholder="z. B. +49 151 12345678"
+                :classes="inputClasses"
+                help="Falls du eine separate Nummer für WhatsApp nutzt."
+              />
+
+              <FormKit
                 type="number"
                 name="price"
                 label="Preis (ab)"
@@ -231,6 +240,7 @@ const register = async (form) => {
         company_name: form.company_name,
         email: form.email,
         phone: form.phone,
+        whatsapp: form.whatsapp || '',
         address: form.address || '',
         city: form.city || '',
         postal_code: form.postal_code || '',

--- a/src/pages/user/CompanyDetailView.vue
+++ b/src/pages/user/CompanyDetailView.vue
@@ -43,6 +43,7 @@
 
             <div class="grid gap-3 sm:grid-cols-2">
               <DataRow label="Telefon" :value="company.phone || 'Keine Nummer'" />
+              <DataRow label="WhatsApp" :value="company.whatsapp || 'Keine Nummer'" />
               <DataRow label="Preis" :value="company.price ? `ab ${company.price} €` : 'auf Anfrage'" />
               <DataRow
                 v-if="company.is_247 && company.emergency_price"
@@ -93,6 +94,16 @@
               >
                 <i class="fa fa-phone"></i>
                 Jetzt anrufen
+              </a>
+              <a
+                v-if="whatsappLink"
+                :href="whatsappLink"
+                class="btn flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600"
+                target="_blank"
+                rel="noopener"
+              >
+                <i class="fa fa-whatsapp"></i>
+                Über WhatsApp schreiben
               </a>
             </div>
           </div>
@@ -161,6 +172,13 @@ const openStatus = computed(() => {
   if (isOpen.value) return 'Jetzt geöffnet'
   if (company.value.is_247 && company.value.emergency_price) return `Notdienst verfügbar – ${company.value.emergency_price} €`
   return 'Derzeit geschlossen'
+})
+
+const whatsappLink = computed(() => {
+  const raw = company.value.whatsapp
+  if (!raw) return ''
+  const normalized = raw.toString().replace(/[^0-9]/g, '')
+  return normalized ? `https://wa.me/${normalized}` : ''
 })
 
 function dayStatus(day) {

--- a/src/services/company.js
+++ b/src/services/company.js
@@ -9,6 +9,8 @@ const FALLBACK_COMPANIES = [
     verified: true,
     logo_url:
       'https://images.unsplash.com/photo-1526304640581-d334cdbbf45e?auto=format&fit=crop&w=160&h=160&q=80',
+    phone: '+49 30 1234567',
+    whatsapp: '+49 151 2345678',
     postal_code: '10115',
     city: 'Berlin',
     address: 'Invalidenstraße 12',
@@ -32,6 +34,8 @@ const FALLBACK_COMPANIES = [
     verified: true,
     logo_url:
       'https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=160&h=160&q=80',
+    phone: '+49 40 9876543',
+    whatsapp: '+49 160 9876543',
     postal_code: '20095',
     city: 'Hamburg',
     address: 'Spitalerstraße 7',


### PR DESCRIPTION
## Summary
- allow companies to capture an optional WhatsApp number during registration and profile management
- expose the WhatsApp contact details in the dashboard and company detail view with a direct chat link
- update demo fallback companies with example WhatsApp numbers for consistent sample data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da73ee90848321832e7c62fa4a36b8