### PR TITLE
Fix common UI component reactivity issues

### DIFF
--- a/src/components/common/Button.vue
+++ b/src/components/common/Button.vue
@@ -4,7 +4,7 @@
     class="btn"
     :class="sizeClass"
     :disabled="disabled"
-    @click="$emit('click')"
+    @click="emit('click')"
   >
     <slot />
   </button>
@@ -20,6 +20,8 @@ const props = defineProps({
   },
   disabled: Boolean
 })
+
+const emit = defineEmits(['click'])
 
 const sizeClass = computed(() =>
   props.size === 'sm'

--- a/src/components/common/Loader.vue
+++ b/src/components/common/Loader.vue
@@ -11,6 +11,8 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
+
 const props = defineProps({
   size: {
     type: Number,
@@ -18,5 +20,8 @@ const props = defineProps({
   }
 })
 
-const style = `width: ${props.size}px; height: ${props.size}px;`
+const style = computed(() => ({
+  width: `${props.size}px`,
+  height: `${props.size}px`
+}))
 </script>


### PR DESCRIPTION
## Summary
- declare the Button component's click event and use the typed emitter
- compute the Loader component's inline styles so size updates stay reactive

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbd6b743188321a3b3f500d26dd394