### PR TITLE
Use contact email field for messaging action

### DIFF
--- a/src/pages/user/CompanyDetailView.vue
+++ b/src/pages/user/CompanyDetailView.vue
@@ -101,7 +101,7 @@
                 Jetzt anrufen
               </button>
               <button
-                v-if="company.email"
+                v-if="company.contact_email"
                 type="button"
                 class="btn flex w-full items-center justify-center gap-2 sm:w-auto"
                 @click="openReview('message')"
@@ -189,9 +189,9 @@ const activeTracking = computed(() =>
 )
 
 const contactEmailLink = computed(() => {
-  if (!company.value.email) return ''
+  if (!company.value.contact_email) return ''
   const subject = encodeURIComponent('Anfrage über Magikey')
-  return `mailto:${company.value.email}?subject=${subject}`
+  return `mailto:${company.value.contact_email}?subject=${subject}`
 })
 
 const mapUrl = computed(() => {


### PR DESCRIPTION
## Summary
- show the "Jetzt anschreiben" action when a company has a contact email
- build the mailto link with the stored contact_email field so the button opens the correct composer

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbddbaf7c88321b769bb6874939697