### PR TITLE
Fix password validation to accept six characters

### DIFF
--- a/src/components/common/PasswordField.vue
+++ b/src/components/common/PasswordField.vue
@@ -5,7 +5,7 @@
       type="password"
       :name="name"
       :label="label"
-      validation="required|min:6"
+      validation="required|length:6,255"
       :placeholder="placeholder"
       :help="help"
       :classes="inputClasses"

--- a/src/components/company/Login.vue
+++ b/src/components/company/Login.vue
@@ -24,7 +24,7 @@
       type="password"
       name="password"
       label="Passwort"
-      validation="required|min:6"
+      validation="required|length:6,255"
       v-model="password"
       :classes="{
         outer: 'space-y-2',


### PR DESCRIPTION
## Summary
- replace the FormKit min rule with a length range on shared password field component so six-character passwords pass validation
- apply the same validation update to the company login form for consistency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbee9383488321b295eebd0fe57ed2