### PR TITLE
Make auth action links configurable per deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,5 @@ VITE_FIREBASE_STORAGE_BUCKET=
 VITE_FIREBASE_MESSAGING_SENDER_ID=
 VITE_FIREBASE_APP_ID=
 VITE_GOOGLE_MAPS_API_KEY=
+# Base URL used for Firebase auth action links. Must match an allowlisted domain.
 VITE_PUBLIC_URL=https://magikey.de

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -12,6 +12,14 @@ import {
   sendEmailVerification,
 } from 'firebase/auth'
 
+function getAppUrl() {
+  const fallbackOrigin =
+    typeof window !== 'undefined' && window?.location?.origin
+      ? window.location.origin
+      : ''
+  return (import.meta.env.VITE_PUBLIC_URL ?? fallbackOrigin).replace(/\/$/, '')
+}
+
 // Meldet einen Benutzer mit E-Mail und Passwort an.
 function ensureAuthAvailable() {
   if (!isFirebaseConfigured || !auth) {
@@ -30,7 +38,7 @@ export async function resetPassword(email) {
   ensureAuthAvailable()
   const actionCodeSettings = {
     // Link, den der Nutzer nach dem Klick in der E-Mail öffnet.
-    url: 'https://magikey.de/reset-password/confirm',
+    url: `${getAppUrl()}/reset-password/confirm`,
     // Der Link soll direkt in dieser Web-App geöffnet werden.
     handleCodeInApp: true,
   }
@@ -56,7 +64,7 @@ export async function sendVerificationEmail(user = auth.currentUser) {
   ensureAuthAvailable()
   if (!user) throw new Error('No user')
   const actionCodeSettings = {
-    url: 'https://magikey.de/verify',
+    url: `${getAppUrl()}/verify`,
     handleCodeInApp: true,
   }
   return sendEmailVerification(user, actionCodeSettings)

--- a/src/services/auth.test.js
+++ b/src/services/auth.test.js
@@ -1,5 +1,5 @@
 // Diese Datei überprüft die Authentifizierungsfunktionen mit Tests.
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 vi.mock('@/firebase', () => ({
   auth: 'auth-instance',
@@ -20,6 +20,11 @@ import { signInWithEmailAndPassword, createUserWithEmailAndPassword, sendPasswor
 describe('auth service', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubEnv('VITE_PUBLIC_URL', 'https://app.magikey.test')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   it('login calls firebase signInWithEmailAndPassword', async () => {
@@ -30,7 +35,7 @@ describe('auth service', () => {
   it('resetPassword calls firebase sendPasswordResetEmail', async () => {
     await resetPassword('mail@example.com')
     expect(sendPasswordResetEmail).toHaveBeenCalledWith('auth-instance', 'mail@example.com', {
-      url: 'https://magikey.de/reset-password/confirm',
+      url: 'https://app.magikey.test/reset-password/confirm',
       handleCodeInApp: true,
     })
   })
@@ -49,7 +54,7 @@ describe('auth service', () => {
     const user = { uid: '1' }
     await sendVerificationEmail(user)
     expect(sendEmailVerification).toHaveBeenCalledWith(user, {
-      url: 'https://magikey.de/verify',
+      url: 'https://app.magikey.test/verify',
       handleCodeInApp: true,
     })
   })


### PR DESCRIPTION
## Summary
- derive auth action code URLs from the configured public URL helper
- update auth service tests to stub the deployment URL when asserting links
- document the VITE_PUBLIC_URL environment variable for Firebase allowlisting

## Testing
- npm run test -- src/services/auth.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc1addcafc8321a5e524523ab0b5dd