### PR TITLE
Add review request Firestore security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -21,6 +21,38 @@ service cloud.firestore {
       allow read, update, delete: if false;
     }
 
+    match /review_requests/{requestId} {
+      allow create: if request.resource.data.keys().hasOnly([
+            'company_id',
+            'company_name',
+            'contact_type',
+            'customer_email',
+            'created_at',
+            'status'
+          ]) &&
+          request.resource.data.keys().hasAll([
+            'company_id',
+            'company_name',
+            'contact_type',
+            'customer_email',
+            'created_at',
+            'status'
+          ]) &&
+          request.resource.data.company_id is string &&
+          request.resource.data.company_id.size() > 0 &&
+          request.resource.data.company_name is string &&
+          request.resource.data.company_name.size() > 0 &&
+          request.resource.data.contact_type is string &&
+          request.resource.data.contact_type.size() > 0 &&
+          request.resource.data.customer_email is string &&
+          request.resource.data.customer_email.size() > 0 &&
+          request.resource.data.created_at is timestamp &&
+          request.resource.data.status is string &&
+          request.resource.data.status.size() > 0;
+
+      allow read, update, delete: if false;
+    }
+
     // Deny all other access by default
     match /{document=**} {
       allow read, write: if false;


### PR DESCRIPTION
## Summary
- add Firestore security rules for review request submissions with field validation
- keep review request documents write-only by disallowing read, update, and delete operations

## Testing
- npx firebase-tools --version *(fails: npm error code E403 403 Forbidden - GET https://registry.npmjs.org/firebase-tools)*

------
https://chatgpt.com/codex/tasks/task_e_68dc24a1c02c8321a8ac460564dccbe2