### PR TITLE
Allow admins to manage pending companies

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,18 +1,32 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    function requestEmail() {
+      return request.auth != null && request.auth.token.email is string
+        ? request.auth.token.email
+        : '';
+    }
+
+    function isAdminUser() {
+      return requestEmail() == 'jen@preisser.de' || requestEmail().matches('.*@magikey\\.de$');
+    }
+
+    function isCompanyOwner(companyId) {
+      return request.auth != null && request.auth.uid == companyId;
+    }
+
     match /companies/{companyId} {
       // Owners can manage their own company profile
-      allow create: if request.auth != null && request.auth.uid == companyId;
-      allow read: if resource.data.verified == true || (request.auth != null && request.auth.uid == companyId);
+      allow create: if isCompanyOwner(companyId);
+      allow read: if resource.data.verified == true || isCompanyOwner(companyId) || isAdminUser();
       allow update: if
-        request.auth != null &&
-        request.auth.uid == companyId &&
+        (isCompanyOwner(companyId) &&
         (
           request.resource.data.verified == resource.data.verified ||
           (resource.data.verified == false && request.resource.data.verified == true)
-        );
-      allow delete: if request.auth != null && request.auth.uid == companyId;
+        )) ||
+        isAdminUser();
+      allow delete: if isCompanyOwner(companyId) || isAdminUser();
     }
 
     match /notify_me/{docId} {


### PR DESCRIPTION
## Summary
- add helper functions in Firestore rules to recognise admin users and company owners
- permit admin accounts to read, update, and delete company documents regardless of verification status

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd04e226fc8321aa613d74c8a2be42