### PR TITLE
Redesign admin dashboard with metrics and improved layout

### DIFF
--- a/src/pages/admin/AdminDashboardView.vue
+++ b/src/pages/admin/AdminDashboardView.vue
@@ -25,50 +25,90 @@
         </div>
       </header>
 
-      <div class="grid gap-6 lg:grid-cols-[0.85fr,1.15fr]">
-        <aside class="glass-card space-y-5 p-6 sm:p-8">
-          <div class="flex items-center justify-between">
+      <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <article class="summary-card summary-card--pending">
+          <div class="summary-card__label">
+            <i class="fa fa-hourglass-half"></i>
+            Ausstehende Profile
+          </div>
+          <p class="summary-card__value">{{ pendingCount }}</p>
+          <p class="summary-card__hint">Warten auf Freigabe</p>
+        </article>
+        <article class="summary-card summary-card--review">
+          <div class="summary-card__label">
+            <i class="fa fa-tasks"></i>
+            In Bearbeitung
+          </div>
+          <p class="summary-card__value">{{ inReviewCount }}</p>
+          <p class="summary-card__hint">Aktive Prüfungen</p>
+        </article>
+        <article class="summary-card summary-card--verified">
+          <div class="summary-card__label">
+            <i class="fa fa-shield-check"></i>
+            Verifizierte Profile
+          </div>
+          <p class="summary-card__value">{{ verifiedCount }}</p>
+          <p class="summary-card__hint">Live in der Suche</p>
+        </article>
+        <article class="summary-card summary-card--total">
+          <div class="summary-card__label">
+            <i class="fa fa-database"></i>
+            Gesamtbestand
+          </div>
+          <p class="summary-card__value">{{ totalCount }}</p>
+          <p class="summary-card__hint">Aktualisiert {{ lastRefreshLabel }}</p>
+        </article>
+      </div>
+
+      <div class="dashboard-grid gap-6 lg:grid-cols-[340px,1fr]">
+        <aside class="dashboard-sidebar glass-card space-y-6 p-6 sm:p-8">
+          <div class="flex items-center justify-between gap-3">
             <h2 class="text-lg font-semibold text-slate-900">Unternehmen</h2>
             <button type="button" class="pill-checkbox text-xs" @click="loadCompanies" :disabled="loading">
               <i class="fa fa-sync"></i>
               Aktualisieren
             </button>
           </div>
-          <div class="flex items-center gap-2 text-xs text-slate-500">
-            <button
-              type="button"
-              class="filter-chip"
-              :class="{ active: filter === 'pending' }"
-              @click="filter = 'pending'"
-            >
-              <i class="fa fa-hourglass-half"></i>
-              In Prüfung
-            </button>
-            <button
-              type="button"
-              class="filter-chip"
-              :class="{ active: filter === 'verified' }"
-              @click="filter = 'verified'"
-            >
-              <i class="fa fa-check-circle"></i>
-              Verifiziert
-            </button>
-            <button
-              type="button"
-              class="filter-chip"
-              :class="{ active: filter === 'all' }"
-              @click="filter = 'all'"
-            >
-              <i class="fa fa-list"></i>
-              Alle
-            </button>
+
+          <div class="space-y-3">
+            <label class="search-field">
+              <i class="fa fa-search"></i>
+              <input v-model="searchTerm" type="search" placeholder="Suchen nach Name, Ort oder PLZ" />
+            </label>
+            <div class="flex flex-wrap gap-2 text-xs text-slate-500">
+              <button
+                type="button"
+                class="filter-chip"
+                :class="{ active: filter === 'pending' }"
+                @click="filter = 'pending'"
+              >
+                <i class="fa fa-hourglass-half"></i>
+                In Prüfung
+              </button>
+              <button
+                type="button"
+                class="filter-chip"
+                :class="{ active: filter === 'verified' }"
+                @click="filter = 'verified'"
+              >
+                <i class="fa fa-check-circle"></i>
+                Verifiziert
+              </button>
+              <button type="button" class="filter-chip" :class="{ active: filter === 'all' }" @click="filter = 'all'">
+                <i class="fa fa-list"></i>
+                Alle
+              </button>
+            </div>
           </div>
 
           <div v-if="loading" class="flex items-center justify-center py-10">
             <Loader :size="48" />
           </div>
-          <ul v-else class="space-y-2">
-            <li v-if="!filteredCompanies.length" class="rounded-2xl border border-dashed border-slate-200 p-5 text-center text-sm text-slate-500">
+          <ul v-else class="dashboard-company-list space-y-2">
+            <li
+              v-if="!filteredCompanies.length"
+              class="rounded-2xl border border-dashed border-slate-200 p-5 text-center text-sm text-slate-500"
+            >
               Keine Unternehmen im ausgewählten Filter.
             </li>
             <li
@@ -81,7 +121,9 @@
                 <div class="flex items-center justify-between gap-3">
                   <div class="min-w-0 space-y-1">
                     <p class="truncate text-sm font-semibold text-slate-800">{{ companyItem.company_name }}</p>
-                    <p class="truncate text-xs text-slate-500">{{ companyItem.city }} · {{ companyItem.postal_code }}</p>
+                    <p class="truncate text-xs text-slate-500">
+                      {{ companyItem.city }} · {{ companyItem.postal_code }}
+                    </p>
                   </div>
                   <span
                     class="status-pill"
@@ -96,127 +138,160 @@
           </ul>
         </aside>
 
-        <div class="glass-card min-h-[28rem] p-6 sm:p-10">
-          <div v-if="!currentCompany" class="flex h-full flex-col items-center justify-center gap-4 text-center text-slate-500">
+        <div class="dashboard-content glass-card min-h-[28rem] p-6 sm:p-10">
+          <div
+            v-if="!currentCompany"
+            class="flex h-full flex-col items-center justify-center gap-4 text-center text-slate-500"
+          >
             <i class="fa fa-user-lock text-3xl"></i>
-            <p class="max-w-sm text-sm">Wähle links ein Unternehmen aus, um die Verifizierungsdaten zu ergänzen.</p>
+            <p class="max-w-sm text-sm">
+              Wähle links ein Unternehmen aus, um die Verifizierungsdaten zu ergänzen.
+            </p>
           </div>
 
-          <div v-else class="space-y-6">
-            <div class="flex flex-col gap-3 border-b border-white/60 pb-4 sm:flex-row sm:items-center sm:justify-between">
-              <div>
+          <div v-else class="space-y-8">
+            <div class="dashboard-content__header">
+              <div class="space-y-2">
+                <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Ausgewähltes Unternehmen</p>
                 <h2 class="text-2xl font-semibold text-slate-900">{{ currentCompany.company_name }}</h2>
-                <p class="text-sm text-slate-500">{{ currentCompany.address }}, {{ currentCompany.postal_code }} {{ currentCompany.city }}</p>
+                <div class="flex flex-wrap gap-2 text-xs text-slate-500">
+                  <span class="info-chip">
+                    <i class="fa fa-map-marker-alt"></i>
+                    {{ currentCompany.address }}
+                  </span>
+                  <span class="info-chip">
+                    <i class="fa fa-city"></i>
+                    {{ currentCompany.postal_code }} {{ currentCompany.city }}
+                  </span>
+                  <span class="info-chip" v-if="currentCompany.phone">
+                    <i class="fa fa-phone"></i>
+                    {{ currentCompany.phone }}
+                  </span>
+                </div>
               </div>
-              <span class="status-pill" :class="verificationStatusClass">
-                <i class="fa" :class="currentCompany.verified ? 'fa-shield-check' : 'fa-shield-alt'"></i>
-                {{ verificationStatusLabel }}
-              </span>
+              <div class="dashboard-status">
+                <span class="status-pill" :class="verificationStatusClass">
+                  <i class="fa" :class="currentCompany.verified ? 'fa-shield-check' : 'fa-shield-alt'"></i>
+                  {{ verificationStatusLabel }}
+                </span>
+                <p class="dashboard-status__hint">Letzte Änderung: {{ verificationLastUpdate }}</p>
+              </div>
             </div>
 
             <form class="space-y-8" @submit.prevent="saveVerification('in_review')">
-              <section class="space-y-5 rounded-3xl border border-white/60 bg-white/70 p-6">
-                <div class="flex items-center justify-between">
-                  <h3 class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Account &amp; Basisdaten</h3>
-                  <span class="text-xs text-slate-400">UID: {{ currentCompany.id }}</span>
-                </div>
-                <div class="grid gap-4 md:grid-cols-2">
-                  <label class="form-field">
-                    <span>Firmenname</span>
-                    <input v-model="form.company_name" type="text" placeholder="Schlüsseldienst Müller" />
-                  </label>
-                  <label class="form-field">
-                    <span>Login E-Mail</span>
-                    <input v-model="form.email" type="email" placeholder="beispiel@firma.de" />
-                  </label>
-                  <label class="form-field">
-                    <span>Telefonnummer</span>
-                    <input v-model="form.phone" type="tel" placeholder="z. B. 0151 12345678" />
-                  </label>
-                  <label class="form-field">
-                    <span>WhatsApp</span>
-                    <input v-model="form.whatsapp" type="tel" placeholder="z. B. +49 151 987654321" />
-                  </label>
-                </div>
-                <div class="grid gap-4 md:grid-cols-3">
-                  <label class="form-field md:col-span-2">
-                    <span>Straße &amp; Hausnummer</span>
-                    <input v-model="form.address" type="text" placeholder="Musterstraße 1" />
-                  </label>
-                  <label class="form-field">
-                    <span>PLZ</span>
-                    <input v-model="form.postal_code" type="text" placeholder="12345" />
-                  </label>
-                  <label class="form-field">
-                    <span>Ort</span>
-                    <input v-model="form.city" type="text" placeholder="Berlin" />
-                  </label>
-                </div>
-                <div class="grid gap-4 md:grid-cols-3">
-                  <label class="form-field">
-                    <span>Preis (ab)</span>
-                    <input v-model="form.price" type="number" min="0" step="1" placeholder="69" />
-                  </label>
-                  <label class="form-field">
-                    <span>Notdienstpreis</span>
-                    <input
-                      v-model="form.emergency_price"
-                      type="number"
-                      min="0"
-                      step="1"
-                      placeholder="149"
-                      :disabled="!form.is_247"
-                    />
-                  </label>
-                  <label class="form-checkbox">
-                    <input v-model="form.is_247" type="checkbox" />
-                    <span>24/7 Notdienst</span>
-                  </label>
-                </div>
+              <div class="grid gap-6 xl:grid-cols-2">
+                <section class="detail-card space-y-5">
+                  <div class="flex items-center justify-between">
+                    <h3 class="section-label">Account &amp; Kommunikation</h3>
+                    <span class="text-xs text-slate-400">UID: {{ currentCompany.id }}</span>
+                  </div>
+                  <div class="grid gap-4 md:grid-cols-2">
+                    <label class="form-field">
+                      <span>Firmenname</span>
+                      <input v-model="form.company_name" type="text" placeholder="Schlüsseldienst Müller" />
+                    </label>
+                    <label class="form-field">
+                      <span>Login E-Mail</span>
+                      <input v-model="form.email" type="email" placeholder="beispiel@firma.de" />
+                    </label>
+                    <label class="form-field">
+                      <span>Telefonnummer</span>
+                      <input v-model="form.phone" type="tel" placeholder="z. B. 0151 12345678" />
+                    </label>
+                    <label class="form-field">
+                      <span>WhatsApp</span>
+                      <input v-model="form.whatsapp" type="tel" placeholder="z. B. +49 151 987654321" />
+                    </label>
+                    <label class="form-field md:col-span-2">
+                      <span>Kontakt E-Mail</span>
+                      <input v-model="form.contact_email" type="email" placeholder="kontakt@unternehmen.de" />
+                    </label>
+                  </div>
+                </section>
+
+                <section class="detail-card space-y-5">
+                  <h3 class="section-label">Standort &amp; Preise</h3>
+                  <div class="grid gap-4">
+                    <label class="form-field">
+                      <span>Straße &amp; Hausnummer</span>
+                      <input v-model="form.address" type="text" placeholder="Musterstraße 1" />
+                    </label>
+                    <div class="grid gap-4 sm:grid-cols-2">
+                      <label class="form-field">
+                        <span>PLZ</span>
+                        <input v-model="form.postal_code" type="text" placeholder="12345" />
+                      </label>
+                      <label class="form-field">
+                        <span>Ort</span>
+                        <input v-model="form.city" type="text" placeholder="Berlin" />
+                      </label>
+                    </div>
+                    <div class="grid gap-4 sm:grid-cols-3">
+                      <label class="form-field sm:col-span-1">
+                        <span>Preis (ab)</span>
+                        <input v-model="form.price" type="number" min="0" step="1" placeholder="69" />
+                      </label>
+                      <label class="form-field sm:col-span-1">
+                        <span>Notdienstpreis</span>
+                        <input
+                          v-model="form.emergency_price"
+                          type="number"
+                          min="0"
+                          step="1"
+                          placeholder="149"
+                          :disabled="!form.is_247"
+                        />
+                      </label>
+                      <label class="form-checkbox sm:col-span-1">
+                        <input v-model="form.is_247" type="checkbox" />
+                        <span>24/7 Notdienst</span>
+                      </label>
+                    </div>
+                  </div>
+                </section>
+              </div>
+
+              <section class="detail-card space-y-5">
+                <h3 class="section-label">Beschreibung &amp; Kommunikation</h3>
                 <label class="form-field">
                   <span>Beschreibung</span>
                   <textarea v-model="form.description" rows="3" placeholder="Kurzbeschreibung des Angebots"></textarea>
                 </label>
-                <div class="rounded-2xl border border-dashed border-slate-200 bg-white/80 p-4 text-sm">
-                  <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                      <p
-                        class="font-semibold"
-                        :class="form.email_verified ? 'text-emerald-600' : 'text-amber-600'"
-                      >
-                        {{ emailVerificationLabel }}
-                      </p>
-                      <p v-if="!form.email_verified" class="text-xs text-slate-500">
-                        Markiere die E-Mail als bestätigt, sobald du sie erfolgreich geprüft hast.
-                      </p>
-                    </div>
-                    <div class="flex flex-wrap gap-2">
-                      <button
-                        type="button"
-                        class="btn-secondary"
-                        :disabled="saving || form.email_verified"
-                        @click="markEmailVerified"
-                      >
-                        <i class="fa fa-envelope-open"></i>
-                        Als verifiziert markieren
-                      </button>
-                      <button
-                        v-if="form.email_verified"
-                        type="button"
-                        class="btn-outline"
-                        :disabled="saving"
-                        @click="resetEmailVerification"
-                      >
-                        <i class="fa fa-undo"></i>
-                        Status zurücksetzen
-                      </button>
-                    </div>
+                <div class="verification-callout">
+                  <div>
+                    <p class="font-semibold" :class="form.email_verified ? 'text-emerald-600' : 'text-amber-600'">
+                      {{ emailVerificationLabel }}
+                    </p>
+                    <p v-if="!form.email_verified" class="text-xs text-slate-500">
+                      Markiere die E-Mail als bestätigt, sobald du sie erfolgreich geprüft hast.
+                    </p>
+                  </div>
+                  <div class="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      class="btn-secondary"
+                      :disabled="saving || form.email_verified"
+                      @click="markEmailVerified"
+                    >
+                      <i class="fa fa-envelope-open"></i>
+                      Als verifiziert markieren
+                    </button>
+                    <button
+                      v-if="form.email_verified"
+                      type="button"
+                      class="btn-outline"
+                      :disabled="saving"
+                      @click="resetEmailVerification"
+                    >
+                      <i class="fa fa-undo"></i>
+                      Status zurücksetzen
+                    </button>
                   </div>
                 </div>
               </section>
 
-              <section class="space-y-5 rounded-3xl border border-white/60 bg-white/70 p-6">
-                <h3 class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Leistungen &amp; Zeiten</h3>
+              <section class="detail-card space-y-5">
+                <h3 class="section-label">Leistungen &amp; Zeiten</h3>
                 <div class="space-y-3">
                   <p class="text-sm font-medium text-slate-600">Schlosstypen</p>
                   <div class="flex flex-wrap gap-2">
@@ -246,8 +321,8 @@
                 </div>
               </section>
 
-              <section class="space-y-5 rounded-3xl border border-white/60 bg-white/70 p-6">
-                <h3 class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Verifizierungsinformationen</h3>
+              <section class="detail-card space-y-5">
+                <h3 class="section-label">Verifizierungsinformationen</h3>
                 <div class="grid gap-5 md:grid-cols-2">
                   <label class="form-field">
                     <span>Google Unternehmensprofil</span>
@@ -259,7 +334,7 @@
                   </label>
                   <label class="form-field">
                     <span>Offizielle Website</span>
-                    <input v-model="form.website_url" type="url" placeholder="https://" />
+                    <input v-model="form.website_url" type="url" placeholder="https://..." />
                   </label>
                   <label class="form-field">
                     <span>Preis-Einschätzung</span>
@@ -275,25 +350,20 @@
                   </label>
                 </div>
 
-                <label class="form-field">
-                  <span>Interne Notizen</span>
-                  <textarea v-model="form.admin_notes" rows="4" placeholder="Hinweise für das Trust-Team"></textarea>
-                </label>
-
-                <div class="grid gap-4 sm:grid-cols-2">
+                <div class="grid gap-4 md:grid-cols-2">
                   <label class="form-field">
                     <span>Ansprechpartner:in Trust-Team</span>
                     <input v-model="form.assigned_admin" type="text" placeholder="z. B. Max Mustermann" />
                   </label>
-                  <label class="form-field">
-                    <span>Kontakt E-Mail</span>
-                    <input v-model="form.contact_email" type="email" placeholder="kontakt@unternehmen.de" />
+                  <label class="form-field md:col-span-2">
+                    <span>Interne Notizen</span>
+                    <textarea v-model="form.admin_notes" rows="4" placeholder="Hinweise für das Trust-Team"></textarea>
                   </label>
                 </div>
               </section>
 
-              <div class="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50/60 p-5 text-sm text-slate-600 sm:flex-row sm:items-center sm:justify-between">
-                <p class="flex items-center gap-2">
+              <div class="action-bar">
+                <p class="flex items-center gap-2 text-sm text-slate-600">
                   <i class="fa fa-info-circle text-gold"></i>
                   Speichere deine Änderungen oder gib das Unternehmen direkt frei.
                 </p>
@@ -316,8 +386,9 @@
   </section>
 </template>
 
+
 <script setup>
-import { computed, reactive, ref } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 import { db, isFirebaseConfigured } from '@/firebase'
 import {
   collection,
@@ -337,42 +408,49 @@ const loading = ref(true)
 const saving = ref(false)
 const filter = ref('pending')
 const selectedId = ref('')
+const searchTerm = ref('')
 const lastRefresh = ref(null)
 const lockTypeOptions = LOCK_TYPE_OPTIONS
 
-const form = reactive({
-  // Account & Basisdaten
-  company_name: '',
-  email: '',
-  phone: '',
-  whatsapp: '',
-  address: '',
-  postal_code: '',
-  city: '',
-  price: '',
-  emergency_price: '',
-  is_247: false,
-  description: '',
-  lock_types: [],
-  opening_hours: {},
-  email_verified: false,
-  email_verified_at: null,
-  contact_email: '',
-  // Verifizierungsdaten
-  google_place_url: '',
-  google_reviews_url: '',
-  website_url: '',
-  price_statement: '',
-  association_member: false,
-  register_number: '',
-  assigned_admin: '',
-  admin_notes: '',
-})
+function createEmptyForm() {
+  return {
+    // Account & Basisdaten
+    company_name: '',
+    email: '',
+    phone: '',
+    whatsapp: '',
+    address: '',
+    postal_code: '',
+    city: '',
+    price: '',
+    emergency_price: '',
+    is_247: false,
+    description: '',
+    lock_types: [],
+    opening_hours: {},
+    email_verified: false,
+    email_verified_at: null,
+    contact_email: '',
+    // Verifizierungsdaten
+    google_place_url: '',
+    google_reviews_url: '',
+    website_url: '',
+    price_statement: '',
+    association_member: false,
+    register_number: '',
+    assigned_admin: '',
+    admin_notes: '',
+  }
+}
+
+const form = reactive(createEmptyForm())
 
 async function loadCompanies() {
   if (!isFirebaseConfigured || !db) {
     loading.value = false
     companies.value = []
+    selectedId.value = ''
+    resetForm()
     return
   }
   loading.value = true
@@ -383,17 +461,20 @@ async function loadCompanies() {
       .map((document) => ({ id: document.id, ...document.data() }))
       .filter((company) => !company.is_admin)
     lastRefresh.value = new Date()
-    if (companies.value.length && !companies.value.find((c) => c.id === selectedId.value)) {
+    if (!companies.value.length) {
+      selectedId.value = ''
+    } else if (!companies.value.some((c) => c.id === selectedId.value)) {
       selectedId.value = companies.value[0].id
-      hydrateForm()
-    } else {
-      hydrateForm()
     }
   } catch (error) {
     console.error('Unternehmen konnten nicht geladen werden:', error)
   } finally {
     loading.value = false
   }
+}
+
+function resetForm() {
+  Object.assign(form, createEmptyForm())
 }
 
 function hydrateForm() {
@@ -428,16 +509,59 @@ function hydrateForm() {
 
 function selectCompany(id) {
   selectedId.value = id
-  hydrateForm()
 }
 
 const filteredCompanies = computed(() => {
-  if (filter.value === 'all') return companies.value
-  if (filter.value === 'verified') return companies.value.filter((company) => company.verified)
-  return companies.value.filter((company) => !company.verified)
+  let list = [...companies.value]
+
+  if (filter.value === 'verified') {
+    list = list.filter((company) => company.verified)
+  } else if (filter.value === 'pending') {
+    list = list.filter((company) => !company.verified)
+  }
+
+  const term = searchTerm.value.trim().toLowerCase()
+  if (term) {
+    list = list.filter((company) => {
+      const values = [
+        company.company_name,
+        company.city,
+        company.postal_code,
+        company.email,
+      ]
+      return values.some((value) => String(value || '').toLowerCase().includes(term))
+    })
+  }
+
+  return list
 })
 
 const currentCompany = computed(() => companies.value.find((company) => company.id === selectedId.value) || null)
+
+watch(filteredCompanies, (list) => {
+  if (!list.length) {
+    if (selectedId.value) {
+      selectedId.value = ''
+    }
+    return
+  }
+
+  if (!list.some((company) => company.id === selectedId.value)) {
+    selectedId.value = list[0].id
+  }
+})
+
+watch(
+  () => selectedId.value,
+  () => {
+    if (!selectedId.value) {
+      resetForm()
+      return
+    }
+    hydrateForm()
+  },
+  { immediate: true }
+)
 
 const verificationStatusLabel = computed(() => {
   if (!currentCompany.value) return 'Status unbekannt'
@@ -454,10 +578,26 @@ const verificationStatusClass = computed(() => {
 })
 
 const pendingCount = computed(() => companies.value.filter((company) => !company.verified).length)
+const inReviewCount = computed(
+  () =>
+    companies.value.filter(
+      (company) => company.verification?.status === 'in_review' && !company.verified,
+    ).length,
+)
+const verifiedCount = computed(() => companies.value.filter((company) => company.verified).length)
+const totalCount = computed(() => companies.value.length)
 
 const lastRefreshLabel = computed(() => {
   if (!lastRefresh.value) return 'gerade'
   return lastRefresh.value.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })
+})
+
+const verificationLastUpdate = computed(() => {
+  if (!currentCompany.value) return '–'
+  const lastUpdate =
+    currentCompany.value.verification?.last_update || currentCompany.value.updated_at || currentCompany.value.created_at
+  const normalized = normalizeTimestamp(lastUpdate)
+  return normalized ? formatDate(normalized) : 'Noch keine Änderungen'
 })
 
 const emailVerificationLabel = computed(() => {
@@ -605,6 +745,7 @@ loadCompanies()
   padding: 0.35rem 0.9rem;
   font-weight: 600;
   color: rgb(100, 116, 139);
+  transition: background 0.2s ease, border-color 0.2s ease;
 }
 
 .filter-chip.active {
@@ -613,11 +754,122 @@ loadCompanies()
   color: #b45309;
 }
 
+.summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.85), rgba(248, 250, 252, 0.75));
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.summary-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.12);
+}
+
+.summary-card__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.summary-card__value {
+  font-size: 1.9rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.summary-card__hint {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.summary-card--pending {
+  border-color: rgba(248, 191, 64, 0.45);
+  background: linear-gradient(150deg, rgba(254, 243, 199, 0.9), rgba(254, 249, 195, 0.65));
+}
+
+.summary-card--review {
+  border-color: rgba(59, 130, 246, 0.35);
+  background: linear-gradient(150deg, rgba(191, 219, 254, 0.9), rgba(219, 234, 254, 0.65));
+}
+
+.summary-card--verified {
+  border-color: rgba(16, 185, 129, 0.4);
+  background: linear-gradient(150deg, rgba(209, 250, 229, 0.9), rgba(236, 253, 245, 0.65));
+}
+
+.summary-card--total {
+  border-color: rgba(148, 163, 184, 0.4);
+  background: linear-gradient(150deg, rgba(226, 232, 240, 0.9), rgba(248, 250, 252, 0.7));
+}
+
+.dashboard-grid {
+  align-items: flex-start;
+}
+
+.dashboard-sidebar {
+  position: sticky;
+  top: 1.5rem;
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard-company-list {
+  max-height: 28rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+  margin-right: -0.25rem;
+}
+
+.dashboard-company-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.dashboard-company-list::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+}
+
+.search-field {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.7);
+  padding: 0.55rem 0.95rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.search-field input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 0.85rem;
+  color: #1f2937;
+}
+
+.search-field input:focus {
+  outline: none;
+}
+
 .company-item {
   border-radius: 1.5rem;
   border: 1px solid rgba(148, 163, 184, 0.25);
   background: rgba(255, 255, 255, 0.7);
-  transition: border-color 0.2s, box-shadow 0.2s;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
 }
 
 .company-item button {
@@ -627,7 +879,8 @@ loadCompanies()
 .company-item:hover,
 .company-item.active {
   border-color: rgba(248, 191, 64, 0.7);
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.1);
+  transform: translateY(-1px);
 }
 
 .status-pill {
@@ -654,6 +907,52 @@ loadCompanies()
   border: 1px solid rgba(251, 191, 36, 0.45);
 }
 
+.info-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  color: #475569;
+  padding: 0.35rem 0.85rem;
+}
+
+.dashboard-content__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  justify-content: space-between;
+}
+
+.dashboard-status {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.4rem;
+  text-align: right;
+}
+
+.dashboard-status__hint {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.detail-card {
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.72);
+  padding: 1.5rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.section-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
 .form-field {
   display: grid;
   gap: 0.4rem;
@@ -669,6 +968,10 @@ loadCompanies()
   padding: 0.65rem 0.9rem;
   font-size: 0.9rem;
   color: rgb(30, 41, 59);
+}
+
+.form-field textarea {
+  min-height: 6.5rem;
 }
 
 .form-field input:focus,
@@ -696,6 +999,26 @@ loadCompanies()
   border-radius: 0.4rem;
 }
 
+.verification-callout {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-radius: 1.25rem;
+  border: 1px dashed rgba(248, 191, 64, 0.5);
+  background: rgba(255, 249, 196, 0.45);
+  padding: 1.1rem 1.25rem;
+}
+
+.action-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(241, 245, 249, 0.7);
+  padding: 1.2rem 1.5rem;
+}
+
 .btn {
   display: inline-flex;
   align-items: center;
@@ -707,12 +1030,19 @@ loadCompanies()
   font-weight: 700;
   color: rgb(30, 41, 59);
   box-shadow: 0 12px 20px rgba(251, 191, 36, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 24px rgba(251, 191, 36, 0.4);
 }
 
 .btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
   box-shadow: none;
+  transform: none;
 }
 
 .btn-secondary {
@@ -726,6 +1056,11 @@ loadCompanies()
   color: rgb(30, 41, 59);
   background: rgba(148, 163, 184, 0.2);
   border: 1px solid rgba(148, 163, 184, 0.4);
+  transition: background 0.2s ease;
+}
+
+.btn-secondary:hover {
+  background: rgba(148, 163, 184, 0.3);
 }
 
 .btn-secondary:disabled {
@@ -733,10 +1068,51 @@ loadCompanies()
   cursor: not-allowed;
 }
 
+.btn-outline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  border-radius: 999px;
+  padding: 0.55rem 1.2rem;
+  font-weight: 600;
+  color: #475569;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(255, 255, 255, 0.7);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.btn-outline:hover {
+  background: rgba(148, 163, 184, 0.18);
+  color: #1f2937;
+}
+
+.btn-outline:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 @media (max-width: 1024px) {
+  .dashboard-sidebar {
+    position: static;
+  }
+
+  .dashboard-company-list {
+    max-height: none;
+    overflow: visible;
+  }
+
   .btn,
-  .btn-secondary {
+  .btn-secondary,
+  .btn-outline {
     width: 100%;
+  }
+}
+
+@media (min-width: 768px) {
+  .dashboard-content__header {
+    flex-direction: row;
+    align-items: flex-start;
   }
 }
 
@@ -744,5 +1120,29 @@ loadCompanies()
   header h1 {
     font-size: 2rem;
   }
+
+  .detail-card {
+    padding: 1.25rem;
+  }
+
+  .dashboard-status {
+    align-items: flex-start;
+    text-align: left;
+  }
+}
+
+@media (min-width: 640px) {
+  .verification-callout {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .action-bar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
 }
 </style>
+


### PR DESCRIPTION
## Summary
- reorganize the admin dashboard with overview cards, a sticky company list, and clearer section grouping
- add company search, status statistics, and last-update metadata for quicker moderation context
- refresh component styling for verification callouts, action bar, and controls to prevent overlapping cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd0a2542f8832181f0f38c28525109