### PR TITLE
Adjust Firestore role lookup logic

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,17 +2,17 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     function getUserRole() {
-      if (request.auth == null) {
-        return '';
-      }
-
-      let userPath = /databases/$(database)/documents/users/$(request.auth.uid);
-      if (!exists(userPath)) {
-        return '';
-      }
-
-      let userDoc = get(userPath);
-      return userDoc.data.role is string ? userDoc.data.role : '';
+      return request.auth != null
+        ? (
+            exists(/databases/$(database)/documents/users/$(request.auth.uid))
+              ? (
+                  get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role is string
+                    ? get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role
+                    : ''
+                )
+              : ''
+          )
+        : '';
     }
 
     function isAdminUser() {


### PR DESCRIPTION
## Summary
- replace the getUserRole helper with a conditional expression based implementation matching the desired structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de5f2b30188321be5bf214460389a7