### PR TITLE
Ensure admin role cache refreshes on demand

### DIFF
--- a/src/components/company/Login.vue
+++ b/src/components/company/Login.vue
@@ -104,7 +104,7 @@ const login = async () => {
   try {
     const credential = await loginService(email.value, password.value)
     emit('success')
-    const role = await getUserRole(credential.user)
+    const role = await getUserRole(credential.user, { forceRefresh: true })
     setCachedUserRole(credential.user?.uid, role)
     const targetRoute = role === USER_ROLES.ADMIN ? '/admin' : '/dashboard'
     router.push(targetRoute)

--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -206,7 +206,7 @@ async function fetchCompanyData(user) {
     return
   }
 
-  const role = await getUserRole(user)
+  const role = await getUserRole(user, { forceRefresh: true })
   setCachedUserRole(user.uid, role)
   isAdmin.value = role === USER_ROLES.ADMIN
 

--- a/src/pages/company/RegisterView.vue
+++ b/src/pages/company/RegisterView.vue
@@ -342,7 +342,7 @@ const register = async (form) => {
       rolePayload.created_at = timestamp
     }
     await setDoc(userRef, rolePayload, { merge: true })
-    setCachedUserRole(user.uid, USER_ROLES.COMPANY)
+    setCachedUserRole(user.uid, USER_ROLES.COMPANY, { fetchedAt: Date.now() })
     await sendVerificationEmail(user)
     router.push({
       name: 'success',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -126,7 +126,9 @@ router.beforeEach(async (to, from, next) => {
   const requiresAuth = isFirebaseConfigured && to.meta.requiresAuth
   const requiresAdmin = isFirebaseConfigured && to.meta.requiresAdmin
   const isLoginRoute = to.name === 'login'
-  const userRole = user ? await getUserRole(user) : USER_ROLES.USER
+  const userRole = user
+    ? await getUserRole(user, { forceRefresh: requiresAdmin })
+    : USER_ROLES.USER
   const userIsAdmin = userRole === USER_ROLES.ADMIN
 
   if (requiresAuth && !user) {


### PR DESCRIPTION
## Summary
- add TTL-based caching with optional force refresh to the admin role helper
- refresh cached roles when entering admin routes and after auth-sensitive flows
- keep login, header, and registration flows in sync with the new cache helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de64a3d06c832189cbda5228866a2d