### PR TITLE
Fix description validation rule on company registration form

### DIFF
--- a/src/pages/company/RegisterView.vue
+++ b/src/pages/company/RegisterView.vue
@@ -142,7 +142,7 @@
                 name="description"
                 label="Beschreibung"
                 placeholder="Beschreibe dein Angebot in ein paar Sätzen"
-                validation="required|min:20"
+                validation="required|length:20,1000"
                 :classes="textareaClasses"
                 help="Dieser Text wird im Profil angezeigt. Mindestens 20 Zeichen."
               />


### PR DESCRIPTION
## Summary
- ensure the company registration description textarea validates by character length instead of numeric comparison so 20+ characters pass validation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de679212f483218cb96bb2b278b898