### PR TITLE
Fix company read rule for missing documents

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -34,7 +34,7 @@ service cloud.firestore {
     match /companies/{companyId} {
       // Owners can manage their own company profile
       allow create: if isCompanyOwner(companyId);
-      allow read: if resource.data.verified == true || isCompanyOwner(companyId) || isAdminUser();
+      allow read: if (resource != null && resource.data.verified == true) || isCompanyOwner(companyId) || isAdminUser();
       allow update: if
         (isCompanyOwner(companyId) &&
         (


### PR DESCRIPTION
## Summary
- guard the company read security rule against missing documents so owners can read their profile before it exists

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de681cc6c88321b84c852982a52930