### PR TITLE
Improve Cloud Function integration for reverse geocoding

### DIFF
--- a/src/firebase/functions.js
+++ b/src/firebase/functions.js
@@ -1,22 +1,50 @@
 /* global fetch */
+
+function resolveFunctionUrl() {
+  const rawCustomUrl = (import.meta.env?.VITE_FUNCTION_URL ?? '').toString().trim()
+  if (rawCustomUrl) return rawCustomUrl
+
+  const projectId = (import.meta.env?.VITE_FIREBASE_PROJECT_ID ?? '').toString().trim()
+  if (!projectId) return null
+
+  return `https://us-central1-${projectId}.cloudfunctions.net/postalCodeFromCoords`
+}
+
 export async function getPostalFromCoords(lat, lng) {
   if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
     throw new Error('Invalid coordinates')
   }
 
-  const url =
-    import.meta.env.VITE_FUNCTION_URL ||
-    `https://us-central1-${import.meta.env.VITE_FIREBASE_PROJECT_ID}.cloudfunctions.net/postalCodeFromCoords`
+  const url = resolveFunctionUrl()
+  if (!url) {
+    throw new Error('Cloud Function postalCodeFromCoords ist nicht konfiguriert.')
+  }
 
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ lat, lng }),
-  })
+  let res
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ lat, lng }),
+    })
+  } catch (error) {
+    throw new Error(`Cloud Function postalCodeFromCoords konnte nicht erreicht werden: ${error.message}`)
+  }
 
   if (!res.ok) {
-    throw new Error('Request failed')
+    let details = ''
+    try {
+      details = await res.text()
+    } catch (error) {
+      console.warn('Antwort der Cloud Function konnte nicht gelesen werden:', error)
+    }
+    const suffix = details ? ` – ${details}` : ''
+    throw new Error(`Cloud Function postalCodeFromCoords antwortete mit Status ${res.status}${suffix}`)
   }
 
   return res.json()
+}
+
+export const __test__ = {
+  resolveFunctionUrl,
 }

--- a/src/firebase/functions.test.js
+++ b/src/firebase/functions.test.js
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const importFunctionsModule = async () => {
+  const module = await import('@/firebase/functions.js')
+  return module
+}
+
+describe('getPostalFromCoords', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  it('throws for invalid coordinates', async () => {
+    vi.stubEnv('VITE_FUNCTION_URL', 'https://example.com/postalCodeFromCoords')
+    const { getPostalFromCoords } = await importFunctionsModule()
+    await expect(getPostalFromCoords(NaN, 13.4)).rejects.toThrow('Invalid coordinates')
+  })
+
+  it('throws when no function endpoint is configured', async () => {
+    vi.stubEnv('VITE_FUNCTION_URL', '')
+    vi.stubEnv('VITE_FIREBASE_PROJECT_ID', '')
+    const { getPostalFromCoords } = await importFunctionsModule()
+    await expect(getPostalFromCoords(52.5, 13.4)).rejects.toThrow('Cloud Function postalCodeFromCoords ist nicht konfiguriert.')
+  })
+
+  it('propagates HTTP error details', async () => {
+    vi.stubEnv('VITE_FUNCTION_URL', 'https://example.com/postalCodeFromCoords')
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: vi.fn().mockResolvedValue('kaputt'),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { getPostalFromCoords } = await importFunctionsModule()
+    await expect(getPostalFromCoords(52.5, 13.4)).rejects.toThrow(
+      'Cloud Function postalCodeFromCoords antwortete mit Status 500 – kaputt',
+    )
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/postalCodeFromCoords', expect.any(Object))
+  })
+
+  it('returns parsed JSON on success', async () => {
+    vi.stubEnv('VITE_FUNCTION_URL', 'https://example.com/postalCodeFromCoords')
+    const responseJson = { postalCode: '10115' }
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(responseJson),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { getPostalFromCoords } = await importFunctionsModule()
+    await expect(getPostalFromCoords(52.5, 13.4)).resolves.toEqual(responseJson)
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/postalCodeFromCoords', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ lat: 52.5, lng: 13.4 }),
+    })
+  })
+})
+
+describe('resolveFunctionUrl', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+  })
+
+  it('prefers the custom function URL when provided', async () => {
+    vi.stubEnv('VITE_FUNCTION_URL', ' https://custom.url/function ')
+    const {
+      __test__: { resolveFunctionUrl },
+    } = await importFunctionsModule()
+    expect(resolveFunctionUrl()).toBe('https://custom.url/function')
+  })
+
+  it('constructs the default URL from the project ID', async () => {
+    vi.stubEnv('VITE_FUNCTION_URL', '')
+    vi.stubEnv('VITE_FIREBASE_PROJECT_ID', 'magikey-demo')
+    const {
+      __test__: { resolveFunctionUrl },
+    } = await importFunctionsModule()
+    expect(resolveFunctionUrl()).toBe(
+      'https://us-central1-magikey-demo.cloudfunctions.net/postalCodeFromCoords',
+    )
+  })
+
+  it('returns null when nothing is configured', async () => {
+    vi.stubEnv('VITE_FUNCTION_URL', '')
+    vi.stubEnv('VITE_FIREBASE_PROJECT_ID', '')
+    const {
+      __test__: { resolveFunctionUrl },
+    } = await importFunctionsModule()
+    expect(resolveFunctionUrl()).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- make the postalCodeFromCoords helper resilient when Firebase configuration is missing
- add detailed error handling and logging when the Cloud Function responds with errors
- cover the new behaviour with dedicated Vitest tests for the Firebase functions module

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de6f4f68f48321bca4782ebf7aa06a