### PR TITLE
Add thorough unit tests for location and utility helpers

### DIFF
--- a/src/services/location.test.js
+++ b/src/services/location.test.js
@@ -1,0 +1,238 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const getPostalFromCoordsMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/firebase/functions', () => ({
+  getPostalFromCoords: getPostalFromCoordsMock,
+}))
+
+const importLocationModule = async () => import('./location')
+
+describe('location service', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+    vi.unstubAllGlobals()
+    getPostalFromCoordsMock.mockReset()
+  })
+
+  it('returns empty search results for blank queries without calling the API', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const { searchLocations } = await importLocationModule()
+    await expect(searchLocations('   ')).resolves.toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('requests locations from Nominatim and normalises the response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue([
+        {
+          place_id: '123',
+          address: { postcode: '10115', city: 'Berlin' },
+          display_name: 'Berlin, Germany',
+          lat: '52.5200',
+          lon: '13.4050',
+        },
+      ]),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { searchLocations } = await importLocationModule()
+    const results = await searchLocations(' Berlin ', { limit: 3 })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://nominatim.openstreetmap.org/search?format=jsonv2&addressdetails=1&limit=3&countrycodes=de%2Cat%2Cch&q=Berlin&email=kontakt%40magikey.app',
+      {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        signal: undefined,
+      },
+    )
+    expect(results).toEqual([
+      {
+        id: '123',
+        label: '10115 Berlin',
+        postalCode: '10115',
+        city: 'Berlin',
+        lat: 52.52,
+        lng: 13.405,
+        source: 'search',
+      },
+    ])
+  })
+
+  it('falls back to the display name when address information is missing', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue([
+        {
+          place_id: '9',
+          address: {},
+          display_name: 'Musterstadt, Deutschland',
+          lat: '49.0',
+          lon: '8.4',
+        },
+      ]),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { searchLocations } = await importLocationModule()
+    const results = await searchLocations('Musterstadt')
+    expect(results[0]).toMatchObject({ label: 'Musterstadt' })
+  })
+
+  it('reverse geocodes coordinates into postal code and city', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        address: { postcode: '80331', city: 'München' },
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { reverseGeocode } = await importLocationModule()
+    const result = await reverseGeocode(48.137154, 11.576124)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=48.137154&lon=11.576124&addressdetails=1&zoom=18&email=kontakt%40magikey.app',
+      {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        signal: undefined,
+      },
+    )
+    expect(result).toEqual({
+      postalCode: '80331',
+      city: 'München',
+      label: '80331 München',
+      lat: 48.137154,
+      lng: 11.576124,
+      source: 'reverse',
+    })
+  })
+
+  it('throws when reverse geocoding receives invalid coordinates', async () => {
+    const { reverseGeocode } = await importLocationModule()
+    await expect(reverseGeocode('nope', 11)).rejects.toThrow('Ungültige Koordinaten')
+  })
+
+  it('throws when reverse geocoding fails with a network error', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false })
+    vi.stubGlobal('fetch', fetchMock)
+    const { reverseGeocode } = await importLocationModule()
+    await expect(reverseGeocode(48, 11)).rejects.toThrow('Reverse Geocoding fehlgeschlagen')
+  })
+
+  it('detects the current location when geolocation and reverse geocoding succeed', async () => {
+    const getCurrentPosition = vi.fn((success) =>
+      success({ coords: { latitude: 52.5, longitude: 13.4 } }),
+    )
+    vi.stubGlobal('navigator', { geolocation: { getCurrentPosition } })
+    getPostalFromCoordsMock.mockResolvedValue({ postalCode: '10115' })
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        address: { postcode: '10115', city: 'Berlin' },
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const module = await importLocationModule()
+    const result = await module.detectCurrentLocation()
+
+    expect(getCurrentPosition).toHaveBeenCalled()
+    expect(getPostalFromCoordsMock).toHaveBeenCalledWith(52.5, 13.4)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=52.5&lon=13.4&addressdetails=1&zoom=18&email=kontakt%40magikey.app',
+      {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        signal: undefined,
+      },
+    )
+    expect(result).toEqual({
+      postalCode: '10115',
+      city: 'Berlin',
+      label: '10115 Berlin',
+      lat: 52.5,
+      lng: 13.4,
+      source: 'reverse',
+    })
+  })
+
+  it('falls back to postal information when reverse geocoding fails', async () => {
+    const getCurrentPosition = vi.fn((success) =>
+      success({ coords: { latitude: 52.5, longitude: 13.4 } }),
+    )
+    vi.stubGlobal('navigator', { geolocation: { getCurrentPosition } })
+    getPostalFromCoordsMock.mockResolvedValue({ postalCode: '20095' })
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const module = await importLocationModule()
+    const result = await module.detectCurrentLocation()
+
+    expect(result).toEqual({
+      postalCode: '20095',
+      city: '',
+      label: '20095',
+      lat: 52.5,
+      lng: 13.4,
+      source: 'postal',
+    })
+  })
+
+  it('propagates reverse geocoding errors when no postal code is available', async () => {
+    const getCurrentPosition = vi.fn((success) =>
+      success({ coords: { latitude: 52.5, longitude: 13.4 } }),
+    )
+    vi.stubGlobal('navigator', { geolocation: { getCurrentPosition } })
+    getPostalFromCoordsMock.mockResolvedValue({ postalCode: '' })
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const module = await importLocationModule()
+
+    await expect(module.detectCurrentLocation()).rejects.toThrow(
+      'Reverse Geocoding fehlgeschlagen',
+    )
+  })
+
+  it('logs a warning when Firebase reverse geocoding fails but continues with Nominatim data', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const getCurrentPosition = vi.fn((success) =>
+      success({ coords: { latitude: 52.5, longitude: 13.4 } }),
+    )
+    vi.stubGlobal('navigator', { geolocation: { getCurrentPosition } })
+    getPostalFromCoordsMock.mockRejectedValue(new Error('down'))
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        address: { postcode: '10115', city: 'Berlin' },
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const module = await importLocationModule()
+
+    const result = await module.detectCurrentLocation()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Firebase Reverse Geocoding fehlgeschlagen:',
+      expect.any(Error),
+    )
+    expect(result.source).toBe('reverse')
+    expect(result.label).toBe('10115 Berlin')
+  })
+
+  it('throws when geolocation is not supported', async () => {
+    vi.stubGlobal('navigator', { })
+    const module = await importLocationModule()
+    await expect(module.detectCurrentLocation()).rejects.toThrow(
+      'Geolocation wird nicht unterstützt',
+    )
+  })
+})

--- a/src/utils/distance.test.js
+++ b/src/utils/distance.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { haversineDistance } from './distance'
+
+describe('haversineDistance', () => {
+  it('returns zero for identical coordinates', () => {
+    expect(haversineDistance(52.5, 13.4, 52.5, 13.4)).toBe(0)
+  })
+
+  it('calculates the distance between Berlin and Hamburg with reasonable precision', () => {
+    // Known great-circle distance between Berlin and Hamburg is about 255 km.
+    const distance = haversineDistance(52.520008, 13.404954, 53.550341, 10.000654)
+    expect(distance).toBeGreaterThan(250)
+    expect(distance).toBeLessThan(270)
+  })
+
+  it('handles coordinate order symmetry', () => {
+    const forward = haversineDistance(48.137154, 11.576124, 50.110924, 8.682127)
+    const backward = haversineDistance(50.110924, 8.682127, 48.137154, 11.576124)
+    expect(forward).toBeCloseTo(backward, 10)
+  })
+
+  it('returns NaN when any input is not finite', () => {
+    expect(Number.isNaN(haversineDistance(NaN, 0, 0, 0))).toBe(true)
+    expect(Number.isNaN(haversineDistance(0, Infinity, 0, 0))).toBe(true)
+    expect(Number.isNaN(haversineDistance(0, 0, 'a', 0))).toBe(true)
+  })
+})

--- a/src/utils/passwordStrength.test.js
+++ b/src/utils/passwordStrength.test.js
@@ -34,4 +34,13 @@ describe('evaluatePasswordStrength', () => {
       barClass: 'bg-green-500',
     })
   })
+
+  it('handles empty input gracefully', () => {
+    const result = evaluatePasswordStrength()
+    expect(result).toMatchObject({
+      score: 0,
+      percent: 0,
+      label: 'Schwach',
+    })
+  })
 })

--- a/src/utils/time.test.js
+++ b/src/utils/time.test.js
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { formatDuration, formatEta } from './time'
+
+describe('formatDuration', () => {
+  it('returns empty string for non-finite values', () => {
+    expect(formatDuration(NaN)).toBe('')
+    expect(formatDuration(Infinity)).toBe('')
+  })
+
+  it('handles durations under one minute', () => {
+    expect(formatDuration(0.2)).toBe('unter 1 Minute')
+    expect(formatDuration(0.2, { short: true })).toBe('< 1 Min.')
+  })
+
+  it('rounds to whole minutes and hours correctly', () => {
+    expect(formatDuration(1)).toBe('1 Min.')
+    expect(formatDuration(14.6)).toBe('15 Min.')
+    expect(formatDuration(89.5)).toBe('1 Std. 30 Min.')
+  })
+
+  it('normalises 60 minutes to the next full hour', () => {
+    expect(formatDuration(119.6)).toBe('2 Std.')
+    expect(formatDuration(180)).toBe('3 Std.')
+  })
+})
+
+describe('formatEta', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns empty string for invalid timestamp', () => {
+    expect(formatEta(undefined)).toBe('')
+  })
+
+  it('delegates to Date#toLocaleTimeString with German locale', () => {
+    const spy = vi.spyOn(Date.prototype, 'toLocaleTimeString').mockReturnValue('12:34')
+    const result = formatEta(1700000000000)
+    expect(spy).toHaveBeenCalledWith('de-DE', { hour: '2-digit', minute: '2-digit' })
+    expect(result).toBe('12:34')
+  })
+})


### PR DESCRIPTION
## Summary
- add coverage for the distance utility to verify symmetry, known routes, and invalid input handling
- add comprehensive tests for the time formatting helpers, including locale usage and rounding behaviour
- introduce an extensive location service test suite and extend password strength coverage for empty input

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de70eac8e8832199de09d35c72bc9d