### PR TITLE
Filter unverified companies from detail view

### DIFF
--- a/src/services/company.test.js
+++ b/src/services/company.test.js
@@ -46,16 +46,33 @@ describe('company service', () => {
     firestoreMocks.getDoc.mockResolvedValueOnce({
       exists: () => true,
       id: 'a',
-      data: () => ({ name: 'A' })
+      data: () => ({ name: 'A', verified: true, verification: { status: 'verified' } })
     })
     const comp = await getCompany('a')
     expect(firestoreMocks.doc).toHaveBeenCalledWith('db-instance', 'companies', 'a')
-    expect(comp).toEqual({ id: 'a', name: 'A' })
+    expect(comp).toEqual({
+      id: 'a',
+      name: 'A',
+      verified: true,
+      verification: { status: 'verified' }
+    })
   })
 
   it('returns null when company not found', async () => {
     firestoreMocks.getDoc.mockResolvedValueOnce({ exists: () => false })
     const comp = await getCompany('missing')
+    expect(comp).toBeNull()
+  })
+
+  it('returns null when company is not verified', async () => {
+    firestoreMocks.getDoc.mockResolvedValueOnce({
+      exists: () => true,
+      id: 'b',
+      data: () => ({ name: 'B', verified: false, verification: { status: 'pending' } })
+    })
+
+    const comp = await getCompany('b')
+
     expect(comp).toBeNull()
   })
 


### PR DESCRIPTION
## Summary
- ensure `getCompany` returns `null` for records that are not fully verified, including fallback data
- update the company detail view to redirect to the 404 page when no verified company is found and show a loading/empty state
- cover the new behaviour with a Vitest that checks unverified entries are filtered out

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de77cc77e8832194acb36456ac4949