### PR TITLE
Add Mailjet-backed review request emails

### DIFF
--- a/docs/functions-config.md
+++ b/docs/functions-config.md
@@ -1,0 +1,41 @@
+# Funktionen-Konfiguration für den Bewertungsversand
+
+Damit der Firestore-Trigger `onReviewRequestCreated` E-Mails über Mailjet versenden kann, müssen die folgenden Konfigurationswerte gesetzt werden. Verwende dafür die Firebase CLI in deinem Projektverzeichnis:
+
+```bash
+firebase functions:config:set \
+  mailjet.api_key="MJ_API_KEY" \
+  mailjet.api_secret="MJ_API_SECRET" \
+  reviews.sender_email="support@example.com" \
+  reviews.form_url="https://example.com/review" \
+  reviews.subject="Bitte bewerten Sie unser Unternehmen" \
+  reviews.template_id="123456"
+```
+
+Erläuterungen:
+
+- `mailjet.api_key` / `mailjet.api_secret`: Zugangsdaten deines Mailjet-Accounts.
+- `reviews.sender_email`: Absenderadresse, die in der E-Mail angezeigt wird.
+- `reviews.form_url`: Basis-Link zum Bewertungsformular. Die Function hängt automatisch `companyId` und `requestId` als Query-Parameter an.
+- `reviews.subject`: Optionaler Betreff, wenn kein Mailjet-Template verwendet wird.
+- `reviews.template_id`: Optional. Wenn angegeben, wird das Mailjet-Template (ID als Zahl) mit folgenden `Variables` versorgt:
+  - `companyName`
+  - `contactType`
+  - `reviewLink`
+  - `companyId`
+  - `requestId`
+
+Weitere optionale Konfigurationswerte:
+
+```bash
+firebase functions:config:set reviews.reply_to_email="service@example.com"
+```
+
+Wenn `reviews.reply_to_email` gesetzt ist, wird es als Reply-To-Adresse verwendet.
+
+Weitere optionale Felder:
+
+- `reviews.sender_name`: Überschreibt den Absendernamen (Standard: Firmenname aus der Review-Anfrage).
+- `reviews.reply_to_name`: Name für die Reply-To-Adresse.
+
+> Hinweis: In der lokalen Entwicklung wird kein echter Mailversand ausgelöst. Stattdessen schreibt der Client-Service `src/services/review.js` einen Hinweis in die Konsole, welche E-Mail simuliert wurde.

--- a/functions/__mocks__/cors.js
+++ b/functions/__mocks__/cors.js
@@ -1,0 +1,1 @@
+module.exports = () => (req, res, next) => next()

--- a/functions/__mocks__/firebase-admin.js
+++ b/functions/__mocks__/firebase-admin.js
@@ -1,0 +1,3 @@
+module.exports = {
+  initializeApp: () => {},
+}

--- a/functions/__mocks__/firebase-functions.js
+++ b/functions/__mocks__/firebase-functions.js
@@ -1,0 +1,33 @@
+let configData = {}
+
+const logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+}
+
+function config() {
+  return configData
+}
+
+function __setConfig(value) {
+  configData = value
+}
+
+const firestore = {
+  document: () => ({
+    onCreate: (handler) => handler,
+  }),
+}
+
+const https = {
+  onRequest: (handler) => handler,
+}
+
+module.exports = {
+  logger,
+  config,
+  firestore,
+  https,
+  __setConfig,
+}

--- a/functions/__tests__/reviewTrigger.test.js
+++ b/functions/__tests__/reviewTrigger.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createRequire } from 'module'
+
+process.env.MAGIKEY_USE_FUNCTIONS_STUB = 'true'
+
+const require = createRequire(import.meta.url)
+
+const loadCjsModule = (modulePath) => {
+  const resolved = require.resolve(modulePath)
+  delete require.cache[resolved]
+  return require(modulePath)
+}
+
+describe('onReviewRequestCreated trigger', () => {
+  let functionsMock
+
+  beforeEach(() => {
+    functionsMock = loadCjsModule('../../functions/firebaseFunctions.js')
+    functionsMock.__setConfig({})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('forwards the Firestore payload to the mail sender', async () => {
+    const myFunctions = loadCjsModule('../../functions/index.js')
+    const sendSpy = vi
+      .spyOn(myFunctions, '_sendReviewEmail')
+      .mockResolvedValue({ provider: 'mailjet' })
+
+    const payload = {
+      company_id: 'comp-1',
+      company_name: 'Magikey GmbH',
+      contact_type: 'email',
+      customer_email: 'kunde@example.com',
+    }
+
+    await myFunctions.onReviewRequestCreated(
+      { data: () => payload },
+      { params: { requestId: 'req-123' } },
+    )
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    expect(sendSpy).toHaveBeenCalledWith({
+      ...payload,
+      requestId: 'req-123',
+    })
+    sendSpy.mockRestore()
+  })
+})
+
+describe('sendReviewEmail', () => {
+  let reviewMailer
+  let functionsMock
+
+  beforeEach(() => {
+    functionsMock = loadCjsModule('../../functions/firebaseFunctions.js')
+    functionsMock.__setConfig({
+      mailjet: { api_key: 'key', api_secret: 'secret' },
+      reviews: {
+        sender_email: 'support@example.com',
+        form_url: 'https://example.com/review',
+        template_id: '123456',
+      },
+    })
+    reviewMailer = loadCjsModule('../../functions/reviewMailer.js')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('builds the Mailjet request with template variables', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: vi.fn() })
+
+    const result = await reviewMailer.sendReviewEmail(
+      {
+        company_id: 'comp-1',
+        company_name: 'Magikey GmbH',
+        contact_type: 'email',
+        customer_email: 'kunde@example.com',
+        requestId: 'req-123',
+      },
+      { fetchImpl: fetchMock },
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, options] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://api.mailjet.com/v3.1/send')
+    expect(options.method).toBe('POST')
+    expect(options.headers.Authorization).toBe(`Basic ${Buffer.from('key:secret').toString('base64')}`)
+    const body = JSON.parse(options.body)
+    expect(body.Messages).toHaveLength(1)
+    const message = body.Messages[0]
+    expect(message.TemplateID).toBe(123456)
+    expect(message.Variables).toMatchObject({
+      companyName: 'Magikey GmbH',
+      contactType: 'email',
+      companyId: 'comp-1',
+      requestId: 'req-123',
+    })
+    expect(message.Variables.reviewLink).toContain('companyId=comp-1')
+    expect(message.Variables.reviewLink).toContain('requestId=req-123')
+    expect(result).toMatchObject({ provider: 'mailjet', requestId: 'req-123' })
+  })
+})

--- a/functions/cors.js
+++ b/functions/cors.js
@@ -1,0 +1,5 @@
+const useStub = process.env.MAGIKEY_USE_FUNCTIONS_STUB === 'true'
+
+const corsModule = useStub ? require('./__mocks__/cors') : require('cors')
+
+module.exports = corsModule

--- a/functions/firebaseAdmin.js
+++ b/functions/firebaseAdmin.js
@@ -1,0 +1,7 @@
+const useStub = process.env.MAGIKEY_USE_FUNCTIONS_STUB === 'true'
+
+const adminModule = useStub
+  ? require('./__mocks__/firebase-admin')
+  : require('firebase-admin')
+
+module.exports = adminModule

--- a/functions/firebaseFunctions.js
+++ b/functions/firebaseFunctions.js
@@ -1,0 +1,7 @@
+const useStub = process.env.MAGIKEY_USE_FUNCTIONS_STUB === 'true'
+
+const functionsModule = useStub
+  ? require('./__mocks__/firebase-functions')
+  : require('firebase-functions')
+
+module.exports = functionsModule

--- a/functions/reviewMailer.js
+++ b/functions/reviewMailer.js
@@ -1,0 +1,132 @@
+const functions = require('./firebaseFunctions')
+
+function buildReviewLink(baseUrl, companyId, requestId) {
+  if (!baseUrl) return ''
+  try {
+    const url = new URL(baseUrl)
+    if (companyId) url.searchParams.set('companyId', companyId)
+    if (requestId) url.searchParams.set('requestId', requestId)
+    return url.toString()
+  } catch (err) {
+    functions.logger.warn('Invalid review form URL provided', { baseUrl, error: err.message })
+    return baseUrl
+  }
+}
+
+function extractConfig() {
+  const runtimeConfig = functions.config ? functions.config() : {}
+  return {
+    mailjet: runtimeConfig.mailjet || {},
+    reviews: runtimeConfig.reviews || {},
+  }
+}
+
+function resolveFetch(customFetch) {
+  if (customFetch) return customFetch
+  if (typeof fetch !== 'function') {
+    throw new Error('Global fetch API not available in this runtime')
+  }
+  return fetch
+}
+
+async function sendReviewEmail(payload, options = {}) {
+  const { fetchImpl } = options
+
+  if (!payload || !payload.customer_email) {
+    throw new Error('customer_email missing in payload')
+  }
+
+  const config = extractConfig()
+  const reviewsConfig = config.reviews
+  const mailjetConfig = config.mailjet
+
+  if (!reviewsConfig.sender_email) {
+    throw new Error('reviews.sender_email not configured')
+  }
+  if (!mailjetConfig.api_key || !mailjetConfig.api_secret) {
+    throw new Error('Mailjet API credentials not configured. Set mailjet.api_key and mailjet.api_secret.')
+  }
+
+  const requestId = payload.requestId || ''
+  const reviewLink = buildReviewLink(reviewsConfig.form_url, payload.company_id, requestId)
+
+  const senderName = reviewsConfig.sender_name || payload.company_name || 'Magikey'
+  const subject = reviewsConfig.subject || `Bitte bewerten Sie ${payload.company_name || 'uns'}`
+  const linkText = reviewLink || reviewsConfig.form_url || ''
+
+  const message = {
+    From: {
+      Email: reviewsConfig.sender_email,
+      Name: senderName,
+    },
+    To: [
+      {
+        Email: payload.customer_email,
+        Name: payload.customer_name || '',
+      },
+    ],
+    Subject: subject,
+    TextPart: `Hallo,\n\nwir würden uns über Ihr Feedback freuen. Bitte nutzen Sie folgenden Link:\n${linkText}\n\nVielen Dank!`,
+    HTMLPart: `<!doctype html><html><body><p>Hallo,</p><p>wir würden uns über Ihr Feedback freuen.</p><p><a href="${linkText}">Bewertung abgeben</a></p></body></html>`,
+    CustomID: requestId,
+  }
+
+  if (reviewsConfig.reply_to_email) {
+    message.ReplyTo = {
+      Email: reviewsConfig.reply_to_email,
+      Name: reviewsConfig.reply_to_name || senderName,
+    }
+  }
+
+  if (reviewsConfig.template_id) {
+    const templateId = Number(reviewsConfig.template_id)
+    if (!Number.isFinite(templateId)) {
+      throw new Error('reviews.template_id must be numeric for Mailjet templates')
+    }
+    message.TemplateID = templateId
+    message.TemplateLanguage = true
+    message.Variables = {
+      companyName: payload.company_name || '',
+      contactType: payload.contact_type || '',
+      reviewLink,
+      companyId: payload.company_id || '',
+      requestId,
+    }
+    delete message.Subject
+    delete message.TextPart
+    delete message.HTMLPart
+  }
+
+  const auth = Buffer.from(`${mailjetConfig.api_key}:${mailjetConfig.api_secret}`).toString('base64')
+  const body = JSON.stringify({ Messages: [message] })
+  const fetchFn = resolveFetch(fetchImpl)
+  const response = await fetchFn('https://api.mailjet.com/v3.1/send', {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${auth}`,
+      'Content-Type': 'application/json',
+    },
+    body,
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '')
+    throw new Error(`Mailjet request failed with status ${response.status}: ${errorText}`)
+  }
+
+  functions.logger.info('Review request email dispatched', {
+    to: payload.customer_email,
+    requestId,
+    provider: 'mailjet',
+  })
+  return {
+    provider: 'mailjet',
+    requestId,
+    reviewLink,
+  }
+}
+
+module.exports = {
+  buildReviewLink,
+  sendReviewEmail,
+}

--- a/src/services/review.js
+++ b/src/services/review.js
@@ -10,6 +10,18 @@ export async function createReviewInvite({
   if (!customerEmail) throw new Error('E-Mail-Adresse ist erforderlich')
   if (!companyId) throw new Error('Unternehmens-ID fehlt')
 
+  if (import.meta?.env?.DEV) {
+    console.info(
+      '[DEV] Mock-Mailversand: Review-E-Mail würde gesendet werden an',
+      customerEmail,
+      {
+        companyId,
+        companyName,
+        contactType,
+      },
+    )
+  }
+
   if (!isFirebaseConfigured || !db) {
     console.warn('Firebase nicht konfiguriert. Review-Anfrage wird nicht gespeichert.')
     return { id: null, simulated: true }

--- a/vite.config.js
+++ b/vite.config.js
@@ -35,4 +35,9 @@ export default defineConfig({
     // Increase the limit to avoid warnings when chunks are still large
     chunkSizeWarningLimit: 1000,
   },
+  test: {
+    env: {
+      MAGIKEY_USE_FUNCTIONS_STUB: 'true',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add a Firestore `onReviewRequestCreated` trigger that dispatches Mailjet review invitations through a configurable helper
- introduce Mailjet mailer, Firebase function/admin wrappers, and Vitest coverage for the trigger and payload generation
- document required function configuration and log mock deliveries in development mode on the client

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de773bba108321a1dbab485bf4bc79