### PR TITLE
Fix location filter parsing for combined labels

### DIFF
--- a/src/stores/company.js
+++ b/src/stores/company.js
@@ -23,8 +23,11 @@ export const filteredCompanies = computed(() => {
   const currentMinutes = now.getHours() * 60 + now.getMinutes()
 
   const normalizedLocation = filters.location?.toString().trim()
-  const normalizedLocationDigits = normalizedLocation?.replace(/\s+/g, '')
-  const normalizedLocationLower = normalizedLocation?.toLowerCase()
+  const normalizedLocationDigits = normalizedLocation ? normalizedLocation.replace(/\D/g, '') : ''
+  const normalizedLocationCity = normalizedLocation
+    ? normalizedLocation.replace(/[0-9]/g, ' ').replace(/\s+/g, ' ').trim().toLowerCase()
+    : ''
+  const hasLocationFilter = Boolean(normalizedLocationDigits || normalizedLocationCity)
 
   const locationLat = Number(filters.locationMeta?.lat)
   const locationLng = Number(filters.locationMeta?.lng)
@@ -77,12 +80,12 @@ export const filteredCompanies = computed(() => {
   return companies.value.filter((company) => {
     const postalCode = company.postal_code != null ? company.postal_code.toString().trim() : ''
     const normalizedPostalCode = postalCode.replace(/\s+/g, '')
-    const matchesPLZ =
-      !normalizedLocationDigits ||
-      normalizedPostalCode.includes(normalizedLocationDigits)
+    const matchesPLZ = normalizedLocationDigits
+      ? normalizedPostalCode.includes(normalizedLocationDigits)
+      : false
     const city = company.city != null ? company.city.toString().toLowerCase() : ''
-    const matchesCity = normalizedLocationLower
-      ? city.includes(normalizedLocationLower)
+    const matchesCity = normalizedLocationCity
+      ? city.includes(normalizedLocationCity)
       : false
 
     let isOpen = true
@@ -114,7 +117,7 @@ export const filteredCompanies = computed(() => {
       filters.lockTypes.length === 0 ||
       (company.lock_types || []).some((t) => filters.lockTypes.includes(t))
 
-    let matchesLocation = matchesPLZ || matchesCity
+    let matchesLocation = hasLocationFilter ? matchesPLZ || matchesCity : true
 
     if (hasLocationCoords) {
       const companyCoords = getCompanyCoordinates(company)

--- a/src/stores/company.test.js
+++ b/src/stores/company.test.js
@@ -1,0 +1,57 @@
+import { describe, beforeEach, it, expect } from 'vitest'
+import { useCompanyStore } from './company'
+import { filters } from './filters'
+
+describe('filteredCompanies location filter', () => {
+  const { companies, filteredCompanies } = useCompanyStore()
+
+  beforeEach(() => {
+    companies.value = [
+      {
+        id: 'berlin',
+        company_name: 'Schlüsselservice Berlin',
+        postal_code: '10115',
+        city: 'Berlin',
+        price: 80,
+        opening_hours: {},
+        lock_types: [],
+      },
+      {
+        id: 'hamburg',
+        company_name: 'Notdienst Hamburg',
+        postal_code: '20095',
+        city: 'Hamburg',
+        price: 90,
+        opening_hours: {},
+        lock_types: [],
+      },
+    ]
+
+    filters.openNow = false
+    filters.price = [0, 1000]
+    filters.lockTypes = []
+    filters.location = ''
+    filters.locationMeta = null
+  })
+
+  it('matches combined postal code and city labels', () => {
+    filters.location = '10115 Berlin'
+
+    const resultIds = filteredCompanies.value.map((company) => company.id)
+    expect(resultIds).toEqual(['berlin'])
+  })
+
+  it('matches by city when label contains both postal code and city', () => {
+    filters.location = 'Hamburg'
+
+    const resultIds = filteredCompanies.value.map((company) => company.id)
+    expect(resultIds).toEqual(['hamburg'])
+  })
+
+  it('matches by postal code only', () => {
+    filters.location = '20095'
+
+    const resultIds = filteredCompanies.value.map((company) => company.id)
+    expect(resultIds).toEqual(['hamburg'])
+  })
+})


### PR DESCRIPTION
## Summary
- improve company store location parsing to handle combined postal code and city labels from search suggestions
- treat location filters with digits and text consistently so customer searches work with mixed inputs
- add regression tests to cover combined, city-only, and postal-code-only filters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e165f2416083219f2a9007f9376204