### PR TITLE
Update emergency CTA copy and restrict recommendation to house lock experts

### DIFF
--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -26,7 +26,7 @@
                 @click="requestEmergencyHelp"
               >
                 <i class="fa fa-bell" aria-hidden="true"></i>
-                Jetzt Hilfe beantragen
+                Ausgeschlossen? Jetzt Notdienst beauftragen!
               </button>
               <p class="text-xs font-medium text-slate-500">
                 Empfohlen: {{ emergencyCompany.company_name }}<span v-if="emergencyRating">
@@ -210,7 +210,25 @@ const emergencyCandidate = computed(() => {
     return basePrice !== null ? basePrice : Number.POSITIVE_INFINITY
   }
 
-  const ranked = companies
+  const supportsHouseLock = (company) => {
+    const lockTypes = company?.lock_types
+    if (Array.isArray(lockTypes)) {
+      return lockTypes.some((type) => typeof type === 'string' && type.trim().toLowerCase() === 'house')
+    }
+    if (typeof lockTypes === 'string') {
+      return lockTypes
+        .split(/[,;\n]/)
+        .map((part) => part.trim().toLowerCase())
+        .filter(Boolean)
+        .includes('house')
+    }
+    return false
+  }
+
+  const relevantCompanies = companies.filter(supportsHouseLock)
+  if (!relevantCompanies.length) return null
+
+  const ranked = relevantCompanies
     .map((company) => ({
       company,
       rating: normalizeRating(company),


### PR DESCRIPTION
## Summary
- rename the emergency call-to-action to emphasise immediate house lockout support
- ensure the highlighted emergency provider only includes companies offering Haustürschloss service and keeps existing rating/price tie-breakers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e16b7d901083218ad7ca3676ab4a5b