### PR TITLE
Fix price parsing for company listings and filtering

### DIFF
--- a/src/components/user/SearchResultTile.vue
+++ b/src/components/user/SearchResultTile.vue
@@ -93,6 +93,7 @@ import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { LOCK_TYPE_LABELS, LOCK_TYPE_ICONS } from '@/constants/lockTypes'
 import { DAYS } from '@/constants/days'
+import { parseEuroAmount } from '@/utils/price'
 
 const props = defineProps({
   company: {
@@ -151,25 +152,24 @@ const lockTypes = computed(() =>
   }))
 )
 
+const basePriceValue = computed(() => parseEuroAmount(props.company.price))
+
 const basePrice = computed(() => {
-  const value = Number.parseInt(props.company.price, 10)
+  const value = basePriceValue.value
   if (Number.isFinite(value) && value > 0) return `ab ${euroFormatter.format(value)} €`
   return 'Preis auf Anfrage'
 })
 
-const emergencyPriceValue = computed(() => {
-  const value = Number.parseInt(props.company.emergency_price, 10)
-  if (Number.isFinite(value) && value > 0) return value
-  return null
-})
+const emergencyPriceValue = computed(() => parseEuroAmount(props.company.emergency_price))
 
 const showEmergencyPrice = computed(
-  () => !isOpen.value && props.company.is_247 && emergencyPriceValue.value !== null
+  () => !isOpen.value && props.company.is_247 && Number.isFinite(emergencyPriceValue.value) && emergencyPriceValue.value > 0
 )
 
 const emergencyPrice = computed(() => {
-  if (emergencyPriceValue.value === null) return ''
-  return `Notdienst ${euroFormatter.format(emergencyPriceValue.value)} €`
+  const value = emergencyPriceValue.value
+  if (!Number.isFinite(value) || value <= 0) return ''
+  return `Notdienst ${euroFormatter.format(value)} €`
 })
 
 function navigateToDetails() {

--- a/src/stores/company.js
+++ b/src/stores/company.js
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { getCompanies } from '@/services/company'
 import { filters } from './filters'
 import { DAYS } from '@/constants/days'
+import { parseEuroAmount } from '@/utils/price'
 
 const companies = ref([])
 const loading = ref(false)
@@ -109,8 +110,11 @@ export const filteredCompanies = computed(() => {
       }
     }
 
-    const price = parseInt(company.price || '0')
-    const inPrice = price >= filters.price[0] && price <= filters.price[1]
+    const price = parseEuroAmount(company.price)
+    const hasPrice = Number.isFinite(price)
+    const inPrice = hasPrice
+      ? price >= filters.price[0] && price <= filters.price[1]
+      : filters.price[0] <= 0
 
     const matchesOpen = !filters.openNow || isOpen
     const matchesLock =

--- a/src/stores/company.test.js
+++ b/src/stores/company.test.js
@@ -55,3 +55,36 @@ describe('filteredCompanies location filter', () => {
     expect(resultIds).toEqual(['hamburg'])
   })
 })
+
+describe('filteredCompanies price filter', () => {
+  const { companies, filteredCompanies } = useCompanyStore()
+
+  beforeEach(() => {
+    companies.value = [
+      { id: 'a', price: '59,90', opening_hours: {}, lock_types: [] },
+      { id: 'b', price: '149.50', opening_hours: {}, lock_types: [] },
+      { id: 'c', price: '', opening_hours: {}, lock_types: [] },
+    ]
+
+    filters.openNow = false
+    filters.location = ''
+    filters.locationMeta = null
+    filters.lockTypes = []
+  })
+
+  it('includes companies whose decimal price is within the range', () => {
+    filters.price = [0, 100]
+    expect(filteredCompanies.value.map((company) => company.id)).toEqual(['a', 'c'])
+  })
+
+  it('excludes companies outside the price range', () => {
+    filters.price = [100, 200]
+    expect(filteredCompanies.value.map((company) => company.id)).toEqual(['b'])
+  })
+
+  it('hides companies without price when minimum is above zero', () => {
+    filters.price = [10, 80]
+    const ids = filteredCompanies.value.map((company) => company.id)
+    expect(ids).not.toContain('c')
+  })
+})

--- a/src/utils/price.js
+++ b/src/utils/price.js
@@ -1,0 +1,57 @@
+// Hilfsfunktionen zur Verarbeitung von Preisangaben in Euro.
+
+/**
+ * Wandelt verschiedene Preisformate (z. B. "79,90 €" oder 89.5) in eine Zahl um.
+ * Unterstützt Dezimaltrennzeichen mit Komma oder Punkt und ignoriert übrige Zeichen.
+ *
+ * @param {unknown} value
+ * @returns {number|null}
+ */
+export function parseEuroAmount(value) {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  // Entfernt alle Zeichen außer Ziffern, Komma, Punkt und Minus
+  let normalised = trimmed.replace(/[^0-9,.-]/g, '')
+  if (!normalised || normalised === '-' || normalised === ',') return null
+
+  const lastComma = normalised.lastIndexOf(',')
+  const lastDot = normalised.lastIndexOf('.')
+  let decimalSeparator = null
+
+  if (lastComma >= 0 && lastDot >= 0) {
+    decimalSeparator = lastComma > lastDot ? ',' : '.'
+  } else if (lastComma >= 0) {
+    decimalSeparator = ','
+  } else if (lastDot >= 0) {
+    decimalSeparator = '.'
+  }
+
+  let cleaned = normalised
+
+  if (decimalSeparator) {
+    const thousandSeparator = decimalSeparator === ',' ? '.' : ','
+    const thousandRegex = new RegExp(`\\${thousandSeparator}`, 'g')
+    cleaned = cleaned.replace(thousandRegex, '')
+    if (decimalSeparator === ',') {
+      cleaned = cleaned.replace(',', '.')
+    }
+  } else {
+    cleaned = cleaned.replace(/[.,]/g, '')
+  }
+
+  const numeric = Number(cleaned)
+  return Number.isFinite(numeric) ? numeric : null
+}

--- a/src/utils/price.test.js
+++ b/src/utils/price.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { parseEuroAmount } from './price'
+
+describe('parseEuroAmount', () => {
+  it('returns null for empty values', () => {
+    expect(parseEuroAmount('')).toBeNull()
+    expect(parseEuroAmount('   ')).toBeNull()
+    expect(parseEuroAmount(null)).toBeNull()
+    expect(parseEuroAmount(undefined)).toBeNull()
+  })
+
+  it('keeps numeric inputs as-is', () => {
+    expect(parseEuroAmount(49)).toBe(49)
+    expect(parseEuroAmount(129.9)).toBe(129.9)
+  })
+
+  it('parses decimal strings with comma or dot', () => {
+    expect(parseEuroAmount('79,90')).toBeCloseTo(79.9)
+    expect(parseEuroAmount('89.75')).toBeCloseTo(89.75)
+  })
+
+  it('ignores currency symbols and text', () => {
+    expect(parseEuroAmount('ab 99 €')).toBe(99)
+    expect(parseEuroAmount('119,50 Euro')).toBeCloseTo(119.5)
+  })
+
+  it('handles thousand separators correctly', () => {
+    expect(parseEuroAmount('1.249,50')).toBeCloseTo(1249.5)
+    expect(parseEuroAmount('2,345.10')).toBeCloseTo(2345.1)
+  })
+
+  it('returns null for non-numeric content', () => {
+    expect(parseEuroAmount('keine Angabe')).toBeNull()
+    expect(parseEuroAmount({})).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- add a reusable `parseEuroAmount` helper to normalise Euro price strings
- fix company filtering and customer tiles to use the new helper and handle missing prices gracefully
- extend the company store tests and cover the new helper with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e16939aff48321b69a3fdf57dc9d6d