### PR TITLE
Normalize lock type filtering

### DIFF
--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -30,7 +30,7 @@
               </button>
               <p class="text-xs font-medium text-slate-500">
                 Empfohlen: {{ emergencyCompany.company_name }}<span v-if="emergencyRating">
-                  · {{ emergencyRating.toFixed(1) }} / 5 ⭐
+                  · {{ emergencyRating.toFixed(1) }} / 5 ⭐
                 </span>
               </p>
             </div>
@@ -164,6 +164,7 @@ import { auth, isFirebaseConfigured } from '@/firebase'
 import { onAuthStateChanged } from 'firebase/auth'
 import { LOCK_TYPE_LABELS } from '@/constants/lockTypes'
 import { detectCurrentLocation } from '@/services/location'
+import { hasLockType } from '@/utils/lockTypes'
 
 const NotifyForm = defineAsyncComponent(() => import('@/components/user/NotifyForm.vue'))
 
@@ -210,20 +211,7 @@ const emergencyCandidate = computed(() => {
     return basePrice !== null ? basePrice : Number.POSITIVE_INFINITY
   }
 
-  const supportsHouseLock = (company) => {
-    const lockTypes = company?.lock_types
-    if (Array.isArray(lockTypes)) {
-      return lockTypes.some((type) => typeof type === 'string' && type.trim().toLowerCase() === 'house')
-    }
-    if (typeof lockTypes === 'string') {
-      return lockTypes
-        .split(/[,;\n]/)
-        .map((part) => part.trim().toLowerCase())
-        .filter(Boolean)
-        .includes('house')
-    }
-    return false
-  }
+  const supportsHouseLock = (company) => hasLockType(company?.lock_types, 'house')
 
   const relevantCompanies = companies.filter(supportsHouseLock)
   if (!relevantCompanies.length) return null

--- a/src/stores/company.js
+++ b/src/stores/company.js
@@ -4,6 +4,7 @@ import { getCompanies } from '@/services/company'
 import { filters } from './filters'
 import { DAYS } from '@/constants/days'
 import { parseEuroAmount } from '@/utils/price'
+import { normaliseLockTypeList } from '@/utils/lockTypes'
 
 const companies = ref([])
 const loading = ref(false)
@@ -33,6 +34,7 @@ export const filteredCompanies = computed(() => {
   const locationLat = Number(filters.locationMeta?.lat)
   const locationLng = Number(filters.locationMeta?.lng)
   const hasLocationCoords = Number.isFinite(locationLat) && Number.isFinite(locationLng)
+  const filterLockTypes = new Set(normaliseLockTypeList(filters.lockTypes))
 
   function getCompanyCoordinates(company) {
     const lat = Number(
@@ -117,9 +119,10 @@ export const filteredCompanies = computed(() => {
       : filters.price[0] <= 0
 
     const matchesOpen = !filters.openNow || isOpen
+    const companyLockTypes = normaliseLockTypeList(company.lock_types)
     const matchesLock =
-      filters.lockTypes.length === 0 ||
-      (company.lock_types || []).some((t) => filters.lockTypes.includes(t))
+      filterLockTypes.size === 0 ||
+      companyLockTypes.some((type) => filterLockTypes.has(type))
 
     let matchesLocation = hasLocationFilter ? matchesPLZ || matchesCity : true
 

--- a/src/stores/company.test.js
+++ b/src/stores/company.test.js
@@ -88,3 +88,28 @@ describe('filteredCompanies price filter', () => {
     expect(ids).not.toContain('c')
   })
 })
+
+describe('filteredCompanies lock type filter', () => {
+  const { companies, filteredCompanies } = useCompanyStore()
+
+  beforeEach(() => {
+    companies.value = [
+      { id: '1', lock_types: [' house '] },
+      { id: '2', lock_types: 'car mechanical' },
+      { id: '3', lock_types: 'HOUSE, safe' },
+    ]
+
+    filters.openNow = false
+    filters.price = [0, 1000]
+    filters.location = ''
+    filters.locationMeta = null
+    filters.lockTypes = []
+  })
+
+  it('matches companies by lock types ignoring case and formatting', () => {
+    filters.lockTypes = ['HOUSE']
+
+    const resultIds = filteredCompanies.value.map((company) => company.id)
+    expect(resultIds).toEqual(['1', '3'])
+  })
+})

--- a/src/utils/lockTypes.js
+++ b/src/utils/lockTypes.js
@@ -1,0 +1,39 @@
+// Utility helpers for working with lock type identifiers.
+
+function internalNormaliseLockType(value) {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  return trimmed
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .replace(/__+/g, '_')
+}
+
+export function normaliseLockType(value) {
+  return internalNormaliseLockType(value)
+}
+
+export function normaliseLockTypeList(input) {
+  let values = []
+  if (Array.isArray(input)) {
+    values = input
+  } else if (typeof input === 'string') {
+    values = input.split(/[,;\n]/)
+  } else if (input != null) {
+    values = [input]
+  } else {
+    return []
+  }
+
+  return values
+    .map(internalNormaliseLockType)
+    .filter((type) => typeof type === 'string' && type.length > 0)
+}
+
+export function hasLockType(input, expectedType) {
+  const normalisedExpected = internalNormaliseLockType(expectedType)
+  if (!normalisedExpected) return false
+  return normaliseLockTypeList(input).includes(normalisedExpected)
+}

--- a/src/utils/lockTypes.test.js
+++ b/src/utils/lockTypes.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { hasLockType, normaliseLockTypeList } from './lockTypes'
+
+describe('lockTypes utils', () => {
+  it('normalises lock type arrays and strings', () => {
+    expect(normaliseLockTypeList([' House ', 'car-mechanical', ''])).toEqual([
+      'house',
+      'car_mechanical',
+    ])
+    expect(normaliseLockTypeList('House;Car Mechanical')).toEqual([
+      'house',
+      'car_mechanical',
+    ])
+    expect(normaliseLockTypeList(null)).toEqual([])
+  })
+
+  it('detects lock types regardless of formatting', () => {
+    expect(hasLockType([' House '], 'house')).toBe(true)
+    expect(hasLockType('car mechanical', 'car_mechanical')).toBe(true)
+    expect(hasLockType(undefined, 'house')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add lock type normalisation helpers and reuse them in the emergency recommendation
- normalise company lock type filtering logic and cover additional scenarios with unit tests
- fix lint by replacing irregular whitespace in the home page hero copy

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2200b5920832187e452eb08016fcc