### PR TITLE
Restrict company portal routes to company accounts

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -124,6 +124,14 @@ function isCompanyPortalRoute(routeName) {
   return routeName === 'dashboard' || routeName === 'verification-hold'
 }
 
+function isCompanyRestrictedRoute(routeName) {
+  return (
+    routeName === 'dashboard' ||
+    routeName === 'verification-hold' ||
+    routeName === 'edit'
+  )
+}
+
 async function determineCompanyPortalTarget(user) {
   if (!user?.uid) {
     return 'dashboard'
@@ -180,6 +188,18 @@ export async function navigationGuard(to, from, next) {
       next({ name: 'home' })
     }
     return
+  }
+
+  if (requiresAuth && isCompanyRestrictedRoute(to.name)) {
+    if (userIsAdmin) {
+      next({ name: 'admin-dashboard' })
+      return
+    }
+
+    if (!userIsCompany) {
+      next({ name: 'home' })
+      return
+    }
   }
 
   if (user && isLoginRoute) {

--- a/src/router/index.test.js
+++ b/src/router/index.test.js
@@ -177,6 +177,51 @@ describe('router configuration', () => {
     expect(next).toHaveBeenCalledWith({ name: 'dashboard' })
   })
 
+  it('blocks regular users from accessing company portal routes', async () => {
+    auth.currentUser = { uid: 'user-1' }
+    getUserRoleMock.mockResolvedValueOnce(USER_ROLES.USER)
+
+    const next = vi.fn()
+    await navigationGuard(
+      { name: 'dashboard', meta: { requiresAuth: true } },
+      { name: 'home' },
+      next
+    )
+
+    expect(resolveCompanyPortalRouteMock).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledWith({ name: 'home' })
+  })
+
+  it('prevents regular users from opening the edit route', async () => {
+    auth.currentUser = { uid: 'user-2' }
+    getUserRoleMock.mockResolvedValueOnce(USER_ROLES.USER)
+
+    const next = vi.fn()
+    await navigationGuard(
+      { name: 'edit', meta: { requiresAuth: true } },
+      { name: 'home' },
+      next
+    )
+
+    expect(resolveCompanyPortalRouteMock).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledWith({ name: 'home' })
+  })
+
+  it('routes admins trying to access company pages to the admin dashboard', async () => {
+    auth.currentUser = { uid: 'admin-1' }
+    getUserRoleMock.mockResolvedValueOnce(USER_ROLES.ADMIN)
+
+    const next = vi.fn()
+    await navigationGuard(
+      { name: 'dashboard', meta: { requiresAuth: true } },
+      { name: 'home' },
+      next
+    )
+
+    expect(resolveCompanyPortalRouteMock).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledWith({ name: 'admin-dashboard' })
+  })
+
   it('routes logged in companies away from login to their portal target', async () => {
     auth.currentUser = { uid: 'company-3' }
     getUserRoleMock.mockResolvedValueOnce(USER_ROLES.COMPANY)


### PR DESCRIPTION
## Summary
- add a dedicated guard that limits dashboard, edit and verification routes to company accounts or redirects admins to the admin dashboard
- keep company portal redirection logic intact for verified vs. unverified partners while skipping needless lookups for regular users
- extend router tests to cover the new guard paths for users, companies and admins

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2995e7e3c8321965b9e2c965fb851