### PR TITLE
Refine filtering utilities and clean up tests

### DIFF
--- a/src/components/user/FilterPriceSheet.vue
+++ b/src/components/user/FilterPriceSheet.vue
@@ -30,11 +30,12 @@
 <script setup>
 import { ref, watch } from 'vue'
 import { X } from 'lucide-vue-next'
+import { DEFAULT_PRICE_RANGE } from '@/stores/filters'
 
 const props = defineProps({
   modelValue: {
     type: Array,
-    default: () => [0, 1000]
+    default: () => [...DEFAULT_PRICE_RANGE]
   },
   min: { type: Number, default: 0 },
   max: { type: Number, default: 1000 },
@@ -43,11 +44,21 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue', 'close'])
 
-const range = ref([...props.modelValue])
+function toRangeArray(value) {
+  if (Array.isArray(value) && value.length === 2) {
+    return [...value]
+  }
+  return [...DEFAULT_PRICE_RANGE]
+}
 
-watch(() => props.modelValue, (val) => {
-  range.value = [...val]
-})
+const range = ref(toRangeArray(props.modelValue))
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    range.value = toRangeArray(val)
+  }
+)
 
 function apply() {
   emit('update:modelValue', range.value)

--- a/src/router/index.test.js
+++ b/src/router/index.test.js
@@ -55,7 +55,7 @@ const firebaseMock = vi.hoisted(() => ({ auth: { currentUser: null }, isFirebase
 vi.mock('@/firebase', () => firebaseMock)
 
 const onAuthStateChangedMock = vi.hoisted(() =>
-  vi.fn((auth, onAuth, onError) => {
+  vi.fn((auth, onAuth) => {
     if (typeof onAuth === 'function') {
       onAuth()
     }

--- a/src/stores/company.js
+++ b/src/stores/company.js
@@ -1,13 +1,202 @@
 // Diese Datei verwaltet die Firmenliste und die Filterung.
 import { ref, computed } from 'vue'
 import { getCompanies } from '@/services/company'
-import { filters } from './filters'
+import { filters, DEFAULT_PRICE_RANGE } from './filters'
 import { DAYS } from '@/constants/days'
 import { parseEuroAmount } from '@/utils/price'
 import { normaliseLockTypeList } from '@/utils/lockTypes'
+import { haversineDistance } from '@/utils/distance'
 
 const companies = ref([])
 const loading = ref(false)
+
+const POSTAL_CODE_KEYS = ['postal_code', 'postalCode', 'zip', 'zip_code', 'zipCode']
+const CITY_KEYS = ['city', 'town', 'locality']
+const SERVICE_RADIUS_KEYS = ['service_radius_km', 'serviceRadiusKm', 'serviceRadius']
+
+function readCompanyField(company, keys) {
+  for (const key of keys) {
+    const value = company?.[key]
+    if (value != null) {
+      const stringValue = value.toString().trim()
+      if (stringValue) return stringValue
+    }
+  }
+  return ''
+}
+
+function normalisePostalCode(value) {
+  return value ? value.replace(/\s+/g, '') : ''
+}
+
+function normaliseCity(value) {
+  return value ? value.replace(/\s+/g, ' ').trim().toLowerCase() : ''
+}
+
+function getCompanyPostalCode(company) {
+  return normalisePostalCode(readCompanyField(company, POSTAL_CODE_KEYS))
+}
+
+function getCompanyCity(company) {
+  return normaliseCity(readCompanyField(company, CITY_KEYS))
+}
+
+function pickFirstFinite(values) {
+  for (const value of values) {
+    const num = Number(value)
+    if (Number.isFinite(num)) return num
+  }
+  return null
+}
+
+function getCompanyCoordinates(company) {
+  const lat = pickFirstFinite([
+    company?.coordinates?.lat,
+    company?.coordinates?.latitude,
+    company?.location?.lat,
+    company?.location?.latitude,
+    company?.latitude,
+    company?.lat,
+  ])
+  const lng = pickFirstFinite([
+    company?.coordinates?.lng,
+    company?.coordinates?.longitude,
+    company?.coordinates?.lon,
+    company?.location?.lng,
+    company?.location?.longitude,
+    company?.location?.lon,
+    company?.longitude,
+    company?.lng,
+    company?.lon,
+  ])
+
+  if (lat === null || lng === null) return null
+  return { lat, lng }
+}
+
+function getServiceRadius(company) {
+  const radius = pickFirstFinite(SERVICE_RADIUS_KEYS.map((key) => company?.[key]))
+  if (radius === null || radius < 0) return null
+  return radius
+}
+
+function normaliseLocationFilter(value) {
+  const label = value?.toString().trim() ?? ''
+  if (!label) {
+    return { label: '', digits: '', city: '', hasFilter: false }
+  }
+
+  const digits = label.replace(/\D/g, '')
+  const city = label
+    .replace(/[0-9]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase()
+
+  return {
+    label,
+    digits,
+    city,
+    hasFilter: Boolean(digits || city),
+  }
+}
+
+function companyMatchesLocationText(company, locationFilter) {
+  if (!locationFilter.hasFilter) return true
+
+  const postalCode = getCompanyPostalCode(company)
+  const city = getCompanyCity(company)
+
+  const matchesPostal = locationFilter.digits
+    ? postalCode.includes(locationFilter.digits)
+    : false
+  const matchesCity = locationFilter.city
+    ? city.includes(locationFilter.city)
+    : false
+
+  return matchesPostal || matchesCity
+}
+
+function normalisePriceRange(range) {
+  if (!Array.isArray(range) || range.length < 2) {
+    return { min: DEFAULT_PRICE_RANGE[0], max: DEFAULT_PRICE_RANGE[1] }
+  }
+
+  const rawMin = Number(range[0])
+  const rawMax = Number(range[1])
+  const fallbackMin = DEFAULT_PRICE_RANGE[0]
+  const fallbackMax = DEFAULT_PRICE_RANGE[1]
+
+  const min = Number.isFinite(rawMin) ? rawMin : fallbackMin
+  const max = Number.isFinite(rawMax) ? rawMax : fallbackMax
+
+  if (min > max) {
+    return { min: max, max: min }
+  }
+
+  return { min, max }
+}
+
+function getCurrentDayKey(date) {
+  let index = date.getDay() - 1
+  if (index < 0) index = 6
+  return DAYS[index]
+}
+
+function parseTimeToMinutes(value) {
+  if (typeof value !== 'string') return null
+  const [hours, minutes] = value.split(':').map((part) => Number.parseInt(part, 10))
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return null
+  return hours * 60 + minutes
+}
+
+function isCompanyOpenAt(company, date) {
+  const dayKey = getCurrentDayKey(date)
+  const hours = company?.opening_hours?.[dayKey]
+  if (!hours) return false
+
+  const openMinutes = parseTimeToMinutes(hours.open)
+  const closeMinutes = parseTimeToMinutes(hours.close)
+  if (!Number.isFinite(openMinutes) || !Number.isFinite(closeMinutes)) return false
+
+  const currentMinutes = date.getHours() * 60 + date.getMinutes()
+  return currentMinutes >= openMinutes && currentMinutes <= closeMinutes
+}
+
+function matchesLockTypes(companyLockTypes, filterSet) {
+  if (filterSet.size === 0) return true
+  return companyLockTypes.some((type) => filterSet.has(type))
+}
+
+function matchesLocation(company, locationFilter, referenceCoords) {
+  const matchesText = companyMatchesLocationText(company, locationFilter)
+  if (!referenceCoords) {
+    return matchesText
+  }
+
+  const companyCoords = getCompanyCoordinates(company)
+  const serviceRadius = getServiceRadius(company)
+  if (!companyCoords || serviceRadius === null) {
+    return matchesText
+  }
+
+  const distance = haversineDistance(
+    referenceCoords.lat,
+    referenceCoords.lng,
+    companyCoords.lat,
+    companyCoords.lng
+  )
+
+  if (!Number.isFinite(distance)) {
+    return matchesText
+  }
+
+  if (distance <= serviceRadius) {
+    return true
+  }
+
+  return false
+}
 
 export async function fetchCompanies() {
   loading.value = true
@@ -21,131 +210,40 @@ export async function fetchCompanies() {
 }
 
 export const filteredCompanies = computed(() => {
-  const now = new Date()
-  const currentMinutes = now.getHours() * 60 + now.getMinutes()
-
-  const normalizedLocation = filters.location?.toString().trim()
-  const normalizedLocationDigits = normalizedLocation ? normalizedLocation.replace(/\D/g, '') : ''
-  const normalizedLocationCity = normalizedLocation
-    ? normalizedLocation.replace(/[0-9]/g, ' ').replace(/\s+/g, ' ').trim().toLowerCase()
-    : ''
-  const hasLocationFilter = Boolean(normalizedLocationDigits || normalizedLocationCity)
-
+  const evaluationDate = new Date()
+  const locationFilter = normaliseLocationFilter(filters.location)
   const locationLat = Number(filters.locationMeta?.lat)
   const locationLng = Number(filters.locationMeta?.lng)
   const hasLocationCoords = Number.isFinite(locationLat) && Number.isFinite(locationLng)
-  const filterLockTypes = new Set(normaliseLockTypeList(filters.lockTypes))
-
-  function getCompanyCoordinates(company) {
-    const lat = Number(
-      company?.coordinates?.lat ??
-        company?.coordinates?.latitude ??
-        company?.latitude ??
-        company?.lat
-    )
-    const lng = Number(
-      company?.coordinates?.lng ??
-        company?.coordinates?.longitude ??
-        company?.longitude ??
-        company?.lng
-    )
-    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null
-    return { lat, lng }
-  }
-
-  function getServiceRadius(company) {
-    const radius = Number(company?.service_radius_km)
-    if (!Number.isFinite(radius) || radius < 0) return null
-    return radius
-  }
-
-  function toRadians(value) {
-    return (value * Math.PI) / 180
-  }
-
-  function distanceInKm(a, b) {
-    const R = 6371
-    const dLat = toRadians(b.lat - a.lat)
-    const dLng = toRadians(b.lng - a.lng)
-    const lat1 = toRadians(a.lat)
-    const lat2 = toRadians(b.lat)
-
-    const sinDLat = Math.sin(dLat / 2)
-    const sinDLng = Math.sin(dLng / 2)
-    const haversine =
-      sinDLat * sinDLat +
-      Math.cos(lat1) * Math.cos(lat2) * sinDLng * sinDLng
-
-    const c = 2 * Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine))
-    return R * c
-  }
+  const referenceCoords = hasLocationCoords ? { lat: locationLat, lng: locationLng } : null
+  const lockTypeFilter = new Set(normaliseLockTypeList(filters.lockTypes))
+  const priceRange = normalisePriceRange(filters.price)
 
   return companies.value.filter((company) => {
-    const postalCode = company.postal_code != null ? company.postal_code.toString().trim() : ''
-    const normalizedPostalCode = postalCode.replace(/\s+/g, '')
-    const matchesPLZ = normalizedLocationDigits
-      ? normalizedPostalCode.includes(normalizedLocationDigits)
-      : false
-    const city = company.city != null ? company.city.toString().toLowerCase() : ''
-    const matchesCity = normalizedLocationCity
-      ? city.includes(normalizedLocationCity)
-      : false
+    if (!matchesLocation(company, locationFilter, referenceCoords)) {
+      return false
+    }
 
-    let isOpen = true
-    if (filters.openNow) {
-      try {
-        let dayIndex = now.getDay() - 1
-        if (dayIndex < 0) dayIndex = 6
-        const today = DAYS[dayIndex]
-        const hours = company.opening_hours?.[today]
-        if (hours?.open && hours?.close) {
-          const [oh, om] = hours.open.split(':').map(Number)
-          const [ch, cm] = hours.close.split(':').map(Number)
-          const openM = oh * 60 + om
-          const closeM = ch * 60 + cm
-          isOpen = currentMinutes >= openM && currentMinutes <= closeM
-        } else {
-          isOpen = false
-        }
-      } catch (_) {
-        isOpen = false
-      }
+    if (filters.openNow && !isCompanyOpenAt(company, evaluationDate)) {
+      return false
     }
 
     const price = parseEuroAmount(company.price)
     const hasPrice = Number.isFinite(price)
-    const inPrice = hasPrice
-      ? price >= filters.price[0] && price <= filters.price[1]
-      : filters.price[0] <= 0
-
-    const matchesOpen = !filters.openNow || isOpen
-    const companyLockTypes = normaliseLockTypeList(company.lock_types)
-    const matchesLock =
-      filterLockTypes.size === 0 ||
-      companyLockTypes.some((type) => filterLockTypes.has(type))
-
-    let matchesLocation = hasLocationFilter ? matchesPLZ || matchesCity : true
-
-    if (hasLocationCoords) {
-      const companyCoords = getCompanyCoordinates(company)
-      const serviceRadius = getServiceRadius(company)
-
-      if (companyCoords && serviceRadius !== null) {
-        const distance = distanceInKm(
-          { lat: locationLat, lng: locationLng },
-          companyCoords
-        )
-
-        const withinRadius = distance <= serviceRadius
-        if (withinRadius) {
-          matchesLocation = true
-        } else if (matchesLocation) {
-          matchesLocation = false
-        }
+    if (hasPrice) {
+      if (price < priceRange.min || price > priceRange.max) {
+        return false
       }
+    } else if (priceRange.min > 0) {
+      return false
     }
 
-    return matchesLocation && matchesOpen && inPrice && matchesLock
+    const companyLockTypes = normaliseLockTypeList(company.lock_types)
+    if (!matchesLockTypes(companyLockTypes, lockTypeFilter)) {
+      return false
+    }
+
+    return true
   })
 })
 

--- a/src/stores/company.test.js
+++ b/src/stores/company.test.js
@@ -1,6 +1,6 @@
 import { describe, beforeEach, it, expect, vi, afterEach } from 'vitest'
 import { useCompanyStore } from './company'
-import { filters } from './filters'
+import { filters, DEFAULT_PRICE_RANGE } from './filters'
 
 describe('filteredCompanies location filter', () => {
   const { companies, filteredCompanies } = useCompanyStore()
@@ -28,7 +28,7 @@ describe('filteredCompanies location filter', () => {
     ]
 
     filters.openNow = false
-    filters.price = [0, 1000]
+    filters.price = [...DEFAULT_PRICE_RANGE]
     filters.lockTypes = []
     filters.location = ''
     filters.locationMeta = null
@@ -53,6 +53,25 @@ describe('filteredCompanies location filter', () => {
 
     const resultIds = filteredCompanies.value.map((company) => company.id)
     expect(resultIds).toEqual(['hamburg'])
+  })
+
+  it('matches companies that use camelCase postalCode fields', () => {
+    companies.value = [
+      {
+        id: 'munich',
+        company_name: 'Schlüsseldienst München',
+        postalCode: '80331',
+        city: 'München',
+        price: 70,
+        opening_hours: {},
+        lock_types: [],
+      },
+    ]
+
+    filters.location = '80331'
+
+    const resultIds = filteredCompanies.value.map((company) => company.id)
+    expect(resultIds).toEqual(['munich'])
   })
 })
 
@@ -87,6 +106,12 @@ describe('filteredCompanies price filter', () => {
     const ids = filteredCompanies.value.map((company) => company.id)
     expect(ids).not.toContain('c')
   })
+
+  it('falls back to default range when price filter is invalid', () => {
+    filters.price = ['invalid']
+    const resultIds = filteredCompanies.value.map((company) => company.id)
+    expect(resultIds).toEqual(['a', 'b', 'c'])
+  })
 })
 
 describe('filteredCompanies lock type filter', () => {
@@ -100,7 +125,7 @@ describe('filteredCompanies lock type filter', () => {
     ]
 
     filters.openNow = false
-    filters.price = [0, 1000]
+    filters.price = [...DEFAULT_PRICE_RANGE]
     filters.location = ''
     filters.locationMeta = null
     filters.lockTypes = []
@@ -120,7 +145,7 @@ describe('filteredCompanies openNow filter', () => {
   beforeEach(() => {
     filters.location = ''
     filters.locationMeta = null
-    filters.price = [0, 1000]
+    filters.price = [...DEFAULT_PRICE_RANGE]
     filters.lockTypes = []
     filters.openNow = true
 
@@ -163,10 +188,10 @@ describe('filteredCompanies service radius handling', () => {
 
   beforeEach(() => {
     filters.openNow = false
-    filters.price = [0, 1000]
+    filters.price = [...DEFAULT_PRICE_RANGE]
     filters.lockTypes = []
     filters.location = '10115 Berlin'
-    filters.locationMeta = { lat: 52.520008, lng: 13.404954 }
+    filters.locationMeta = { lat: '52.520008', lng: '13.404954' }
 
     companies.value = [
       {

--- a/src/stores/filters.js
+++ b/src/stores/filters.js
@@ -1,27 +1,34 @@
 // Diese Datei hält die aktuellen Filterwerte bereit.
 import { reactive } from 'vue'
 
+export const DEFAULT_PRICE_RANGE = Object.freeze([0, 1000])
+
 export const filters = reactive({
   openNow: false,
-  price: [0, 1000],
+  price: [...DEFAULT_PRICE_RANGE],
   location: '',
   locationMeta: null,
   lockTypes: []
 })
 
-export function toggleFilter(key) {
-  filters[key] = !filters[key]
-}
-
 export function clearFilter(key) {
   if (key === 'price') {
-    filters.price = [0, 1000]
-  } else if (key === 'location') {
+    filters.price = [...DEFAULT_PRICE_RANGE]
+    return
+  }
+
+  if (key === 'location') {
     filters.location = ''
     filters.locationMeta = null
-  } else if (key === 'lockTypes') {
+    return
+  }
+
+  if (key === 'lockTypes') {
     filters.lockTypes = []
-  } else {
+    return
+  }
+
+  if (Object.prototype.hasOwnProperty.call(filters, key)) {
     filters[key] = false
   }
 }


### PR DESCRIPTION
## Summary
- centralize the shared price range default and make filter resets safer
- harden the price sheet component against invalid ranges
- overhaul company filtering to normalize location and radius handling with broader test coverage

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e29d3b45b88321ac75641090f37540