### PR TITLE
Improve notify form resilience and UX

### DIFF
--- a/src/ui/components/user/NotifyForm.vue
+++ b/src/ui/components/user/NotifyForm.vue
@@ -1,14 +1,23 @@
 <!-- Diese Datei enthält ein Formular für Benachrichtigungs-E-Mails. -->
 <template>
-  <form @submit.prevent="submit" class="mt-2 flex gap-2">
+  <form @submit.prevent="submit" class="mt-2 flex gap-2" novalidate>
     <input
       v-model="email"
       type="email"
       required
       placeholder="E-Mail"
-      class="flex-1 border rounded px-3 py-2 text-sm"
+      autocomplete="email"
+      class="flex-1 rounded border px-3 py-2 text-sm focus:border-gold focus:outline-none focus:ring-1 focus:ring-gold/60"
     />
-    <button class="bg-gold text-black rounded px-4 text-sm">Benachrichtigen</button>
+    <button
+      type="submit"
+      class="rounded bg-gold px-4 text-sm font-semibold text-black transition disabled:cursor-not-allowed disabled:opacity-70"
+      :disabled="isSubmitting"
+      :aria-busy="isSubmitting"
+    >
+      <span v-if="isSubmitting">Wird gesendet…</span>
+      <span v-else>Benachrichtigen</span>
+    </button>
   </form>
 </template>
 
@@ -18,18 +27,36 @@ import { db, isFirebaseConfigured } from '@/core/firebase'
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore'
 
 const email = ref('')
+const isSubmitting = ref(false)
 
 async function submit() {
+  const trimmedEmail = email.value.trim()
+  if (!trimmedEmail) {
+    alert('Bitte gib eine gültige E-Mail-Adresse ein.')
+    return
+  }
+
   if (!isFirebaseConfigured || !db) {
     email.value = ''
     alert('Danke! Wir melden uns bei dir, sobald der Service live ist.')
     return
   }
-  await addDoc(collection(db, 'notify_me'), {
-    email: email.value,
-    created_at: serverTimestamp(),
-  })
-  email.value = ''
-  alert('Danke! Wir melden uns bei dir.')
+
+  if (isSubmitting.value) return
+  isSubmitting.value = true
+
+  try {
+    await addDoc(collection(db, 'notify_me'), {
+      email: trimmedEmail,
+      created_at: serverTimestamp(),
+    })
+    email.value = ''
+    alert('Danke! Wir melden uns bei dir.')
+  } catch (error) {
+    console.error('Fehler beim Speichern der Benachrichtigungsanfrage:', error)
+    alert('Leider konnten wir deine Anfrage nicht speichern. Bitte versuche es später erneut oder schreib uns an info@magikey.de')
+  } finally {
+    isSubmitting.value = false
+  }
 }
 </script>


### PR DESCRIPTION
## Summary
- add client-side email trimming and validation to the notify form
- disable duplicate submissions and show a busy state while persisting data
- handle Firestore failures gracefully with user feedback and logging

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2a52f3cdc8321ba3d5a8737b56461