### PR TITLE
Fix auth listener cleanup during router auth initialization

### DIFF
--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -305,17 +305,26 @@ function waitForAuthInit() {
   return new Promise((resolve) => {
     let unsubscribe = () => {}
 
-    const handleResolve = () => {
+    const finalize = () => {
       authReady = true
-      unsubscribe()
+
+      Promise.resolve()
+        .then(() => {
+          unsubscribe()
+        })
+        .catch(() => {
+          unsubscribe()
+        })
+
       resolve()
     }
 
-    unsubscribe = onAuthStateChanged(
-      auth,
-      handleResolve,
-      handleResolve
-    )
+    const handleError = (error) => {
+      console.error('Fehler beim Beobachten des Auth-Status', error)
+      finalize()
+    }
+
+    unsubscribe = onAuthStateChanged(auth, finalize, handleError)
   })
 }
 


### PR DESCRIPTION
## Summary
- ensure the auth initialization helper unsubscribes from the Firebase listener even when the callback fires synchronously
- log listener errors while still resolving the guard setup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2c17a3c848321a169612d94966511