### PR TITLE
Prevent unverified companies from accessing edit route

### DIFF
--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -408,6 +408,12 @@ export async function navigationGuard(to, from, next) {
       next({ name: 'home' })
       return
     }
+
+    const target = await getCompanyPortalTarget()
+    if (target !== 'dashboard' && target !== to.name) {
+      next({ name: target })
+      return
+    }
   }
 
   if (user && isLoginRoute) {

--- a/src/app/router/index.test.js
+++ b/src/app/router/index.test.js
@@ -184,6 +184,21 @@ describe('router configuration', () => {
     expect(next).toHaveBeenCalledWith({ name: 'dashboard' })
   })
 
+  it('redirects unverified companies away from edit route', async () => {
+    auth.currentUser = { uid: 'company-5' }
+    getUserRoleMock.mockResolvedValueOnce(USER_ROLES.COMPANY)
+    resolveCompanyPortalRouteMock.mockResolvedValueOnce('verification-hold')
+
+    const next = vi.fn()
+    await navigationGuard(
+      { name: 'edit', meta: { requiresAuth: true } },
+      { name: 'dashboard' },
+      next
+    )
+
+    expect(next).toHaveBeenCalledWith({ name: 'verification-hold' })
+  })
+
   it('blocks regular users from accessing company portal routes', async () => {
     auth.currentUser = { uid: 'user-1' }
     getUserRoleMock.mockResolvedValueOnce(USER_ROLES.USER)


### PR DESCRIPTION
## Summary
- ensure the navigation guard redirects unverified companies away from the company edit route
- add unit coverage for the new guard branch in the router tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3844a8c3083218f7da6a5c2214f23