### PR TITLE
Improve Mailjet config guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ VITE_PAYPAL_ME_URL=<paypal-me-link>
 ```
 
 Weitere Details zur Datenstruktur findest du in [docs/firestore.md](docs/firestore.md).
+Hinweise zum Einrichten und Troubleshooting des Mailversands findest du in
+[docs/functions-config.md](docs/functions-config.md) sowie in
+[docs/email-troubleshooting.md](docs/email-troubleshooting.md).
 
 Die Sicherheitsregeln für Firestore und Storage liegen in den Dateien
 `firestore.rules` und `storage.rules`. Sie werden über die

--- a/docs/email-troubleshooting.md
+++ b/docs/email-troubleshooting.md
@@ -1,0 +1,48 @@
+# E-Mail-Versand prüfen
+
+Wenn aus Magikey keine Bewertungs-E-Mails mehr verschickt werden, gehe die folgenden Schritte durch.
+
+## 1. Cloud Functions Konfiguration prüfen
+
+Der Versand läuft über die Firebase Function `onReviewRequestCreated`. Diese benötigt die in [`docs/functions-config.md`](./functions-config.md) beschriebenen Konfigurationswerte. Prüfe sie mit:
+
+```bash
+firebase functions:config:get
+```
+
+Stelle sicher, dass mindestens folgende Werte gesetzt sind:
+
+- `mailjet.api_key`
+- `mailjet.api_secret`
+- `reviews.sender_email`
+- optional: `reviews.form_url`, `reviews.sender_name`, `reviews.reply_to_email`, `reviews.template_id`
+
+Fehlen Werte, kannst du sie so setzen (Beispielwerte ersetzen):
+
+```bash
+firebase functions:config:set \
+  mailjet.api_key="MJ_API_KEY" \
+  mailjet.api_secret="MJ_API_SECRET" \
+  reviews.sender_email="support@example.com" \
+  reviews.form_url="https://example.com/review"
+```
+
+## 2. Firestore Trigger testen
+
+Lege manuell ein Dokument in `review_requests` mit einer `customer_email` an. In der Firebase Console solltest du anschließend in den Logs der Funktion `onReviewRequestCreated` sehen, ob der Versand ausgelöst wurde.
+
+Achte auf Fehlermeldungen vom Typ `Missing Mailjet/Firebase config`. Diese weisen direkt auf fehlende Konfigurationswerte hin.
+
+## 3. Mailjet Konto prüfen
+
+- Ist das Konto verifiziert und nicht im Sandbox-Modus?
+- Gibt es Limitüberschreitungen oder geblockte Empfänger?
+- Siehst du die Requests in den Mailjet Logs?
+
+## 4. Client-Fehler ausschließen
+
+Überprüfe, ob im Admin-Dashboard die Review-Anfrage erfolgreich erstellt wurde. Im Browser-Log solltest du nach einer erfolgreichen Anfrage eine ID für den Firestore-Eintrag sehen.
+
+---
+
+Wenn die Schritte nicht helfen, notiere dir die Fehlermeldungen aus den Cloud-Function-Logs und melde dich mit diesen Details.

--- a/functions/reviewMailer.js
+++ b/functions/reviewMailer.js
@@ -40,11 +40,17 @@ async function sendReviewEmail(payload, options = {}) {
   const reviewsConfig = config.reviews
   const mailjetConfig = config.mailjet
 
-  if (!reviewsConfig.sender_email) {
-    throw new Error('reviews.sender_email not configured')
-  }
-  if (!mailjetConfig.api_key || !mailjetConfig.api_secret) {
-    throw new Error('Mailjet API credentials not configured. Set mailjet.api_key and mailjet.api_secret.')
+  const missingConfig = []
+  if (!mailjetConfig.api_key) missingConfig.push('mailjet.api_key')
+  if (!mailjetConfig.api_secret) missingConfig.push('mailjet.api_secret')
+  if (!reviewsConfig.sender_email) missingConfig.push('reviews.sender_email')
+
+  if (missingConfig.length) {
+    const required = missingConfig.join(', ')
+    throw new Error(
+      `Missing Mailjet/Firebase config: ${required}. ` +
+        'Run "firebase functions:config:set" with the values described in docs/functions-config.md.'
+    )
   }
 
   const requestId = payload.requestId || ''


### PR DESCRIPTION
## Summary
- throw a single descriptive error when required Mailjet/Firebase config values are missing
- add a troubleshooting guide for review email delivery and link it from the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4d6505bac83219a0b5640d8ad6cc1