### PR TITLE
Add floating contact bubble to company detail view

### DIFF
--- a/src/features/user/pages/CompanyDetailView.vue
+++ b/src/features/user/pages/CompanyDetailView.vue
@@ -126,7 +126,7 @@
                       @click="startContact('call')"
                     >
                       <i class="fa fa-phone"></i>
-                      Jetzt anrufen
+                      {{ phoneActionLabel }}
                     </button>
                     <button
                       v-if="whatsappLink"
@@ -135,7 +135,7 @@
                       @click="startContact('whatsapp')"
                     >
                       <i class="fa fa-whatsapp"></i>
-                      Über WhatsApp schreiben
+                      {{ whatsappActionLabel }}
                     </button>
                   </div>
                 </div>
@@ -169,7 +169,7 @@
                     @click="startContact('call')"
                   >
                     <i class="fa fa-phone"></i>
-                    Jetzt anrufen
+                    {{ phoneActionLabel }}
                   </button>
                   <button
                     v-if="whatsappLink"
@@ -178,7 +178,7 @@
                     @click="startContact('whatsapp')"
                   >
                     <i class="fa fa-whatsapp"></i>
-                    Über WhatsApp schreiben
+                    {{ whatsappActionLabel }}
                   </button>
                 </div>
               </div>
@@ -201,6 +201,14 @@
       </div>
     </div>
   </section>
+
+  <FloatingContactBubble
+    v-if="hasContactOptions"
+    :has-options="hasContactOptions"
+    :phone-label="phoneActionLabel"
+    :whatsapp-label="whatsappActionLabel"
+    @select="startContact"
+  />
 
   <ReviewRequestModal
     v-if="company"
@@ -225,6 +233,7 @@ import TrackingRequestPanel from '@/ui/components/tracking/TrackingRequestPanel.
 import ReviewRequestModal from '@/ui/components/reviews/ReviewRequestModal.vue'
 import CompanyReviews from '@/ui/components/reviews/CompanyReviews.vue'
 import { useReviewStore } from '@/core/stores/reviews'
+import FloatingContactBubble from '@/ui/components/user/FloatingContactBubble.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -346,6 +355,18 @@ const whatsappLink = computed(() => {
 })
 
 const hasContactOptions = computed(() => Boolean(phoneLink.value || whatsappLink.value))
+
+const phoneActionLabel = computed(() => {
+  if (!phoneLink.value) return ''
+  const number = company.value?.phone?.toString().trim()
+  return number ? `Anrufen (${number})` : 'Jetzt anrufen'
+})
+
+const whatsappActionLabel = computed(() => {
+  if (!whatsappLink.value) return ''
+  const number = company.value?.whatsapp?.toString().trim()
+  return number ? `WhatsApp (${number})` : 'Über WhatsApp schreiben'
+})
 
 function startContact(action = 'call') {
   pendingAction.value = action

--- a/src/ui/components/user/FloatingContactBubble.vue
+++ b/src/ui/components/user/FloatingContactBubble.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="fixed bottom-6 right-4 z-50 flex flex-col items-end gap-3 sm:right-6">
+    <Transition name="bubble">
+      <div
+        v-if="open && hasOptions"
+        class="flex flex-col items-stretch gap-2 rounded-3xl border border-white/70 bg-white/95 p-3 text-sm text-slate-600 shadow-xl backdrop-blur"
+      >
+        <p class="px-1 text-xs font-semibold uppercase tracking-[0.3em] text-gold/70">Kontakt</p>
+        <button
+          v-if="phoneLabel"
+          type="button"
+          class="btn flex min-w-[12rem] items-center justify-center gap-2"
+          @click="handleClick('call')"
+        >
+          <i class="fa fa-phone"></i>
+          {{ phoneLabel }}
+        </button>
+        <button
+          v-if="whatsappLabel"
+          type="button"
+          class="btn flex min-w-[12rem] items-center justify-center gap-2 bg-emerald-500 hover:bg-emerald-600"
+          @click="handleClick('whatsapp')"
+        >
+          <i class="fa fa-whatsapp"></i>
+          {{ whatsappLabel }}
+        </button>
+      </div>
+    </Transition>
+
+    <button
+      v-if="hasOptions"
+      type="button"
+      class="group relative inline-flex h-14 w-14 items-center justify-center rounded-full bg-gold text-white shadow-lg transition hover:bg-gold/90"
+      @click="toggle"
+    >
+      <span
+        class="absolute inset-0 -z-10 animate-ping rounded-full bg-gold/60 transition group-hover:animate-none"
+        aria-hidden="true"
+      ></span>
+      <i class="fa" :class="open ? 'fa-times' : 'fa-comments'" aria-hidden="true"></i>
+      <span class="sr-only">Kontaktoptionen anzeigen</span>
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+
+const props = defineProps({
+  phoneLabel: {
+    type: String,
+    default: '',
+  },
+  whatsappLabel: {
+    type: String,
+    default: '',
+  },
+  hasOptions: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+const emit = defineEmits(['select'])
+
+const open = ref(false)
+
+const hasOptions = computed(() => props.hasOptions && (props.phoneLabel || props.whatsappLabel))
+
+watch(
+  hasOptions,
+  (next) => {
+    if (!next) {
+      open.value = false
+    }
+  }
+)
+
+function toggle() {
+  if (!hasOptions.value) return
+  open.value = !open.value
+}
+
+function handleClick(action) {
+  emit('select', action)
+  open.value = false
+}
+</script>
+
+<style scoped>
+.bubble-enter-active,
+.bubble-leave-active {
+  transition: all 0.2s ease;
+  transform-origin: bottom right;
+}
+
+.bubble-enter-from,
+.bubble-leave-to {
+  opacity: 0;
+  transform: scale(0.8) translateY(10%);
+}
+</style>


### PR DESCRIPTION
## Summary
- add a floating contact bubble component that pulses and reveals call/WhatsApp actions
- wire the bubble and clearer contact labels into the company detail page alongside existing contact panels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e67c8c3fa883219dfc52dba4472c64